### PR TITLE
Null Pointer is thrown when user trying to authenticate Linkedin has no avatar img

### DIFF
--- a/app/securesocial/provider/providers/LinkedInProvider.java
+++ b/app/securesocial/provider/providers/LinkedInProvider.java
@@ -57,8 +57,10 @@ public class LinkedInProvider extends OAuth1Provider
         }
         user.id.id = me.get(ID).getAsString();
         user.displayName = FoursquareProvider.fullName(me.get(FIRST_NAME).getAsString(),me.get(LAST_NAME).getAsString());
-        user.avatarUrl = me.get(PICTURE_URL).getAsString();
-
+        JsonElement picture = me.get(PICTURE_URL);
+        if(picture != null) {
+            user.avatarUrl = picture.getAsString();
+        }
         // can't get the email because the LinkedIn API does not provide it.
         //user.email = ;
     }


### PR DESCRIPTION
A commit that solves that problem. Just dont try to get the img if user does not have one
