### PR TITLE
Bug when cancel account creation

### DIFF
--- a/app/views/securesocial/UsernamePasswordController/signup.html
+++ b/app/views/securesocial/UsernamePasswordController/signup.html
@@ -75,7 +75,7 @@
 
                 <div class="actions">
                     <input type="submit" value="Create Account" class="btn primary">
-                    <a href="@{securesocial.SecureSocial.login()}"><button class="btn">&{'securesocial.cancel'}</button></a>
+                    <a href="@{securesocial.SecureSocial.login()}" class="btn">&{'securesocial.cancel'}</input></a>
                 </div>
             </fieldset>
         #{/form}


### PR DESCRIPTION
Hello,

I think i find a little bug in account creation. When i click on Cancel button, it seems to submit the form instead of coming back to the login page.
Tested on Firefox 8.0 and IE8.
I correct that just changing the button as an input of button type in signup.html page. It works for firefox 8.0 but IE8 does not seem to like an input button in an a href tag...
I continue to look for an IE8 solution and finally I keep just the a href tag with the css class 'btn' applied.

Thanks for return.

AevoneNle
