### PR TITLE
Possibility to configure "after login redirect" instead just ROOT constant('/').

### DIFF
--- a/app/controllers/securesocial/SecureSocial.java
+++ b/app/controllers/securesocial/SecureSocial.java
@@ -40,6 +40,7 @@ public class SecureSocial extends Controller {
     private static final String ERROR = "error";
     private static final String SECURESOCIAL_AUTH_ERROR = "securesocial.authError";
     private static final String SECURESOCIAL_LOGOUT_REDIRECT = "securesocial.logout.redirect";
+    private static final String SECURESOCIAL_LOGIN_REDIRECT = "securesocial.login.redirect";
     private static final String SECURESOCIAL_SECURE_SOCIAL_LOGIN = "securesocial.SecureSocial.login";
 
     /**
@@ -207,7 +208,8 @@ public class SecureSocial extends Controller {
             flash.keep(ORIGINAL_URL); 
             login();
         }
-        redirect( originalUrl != null ? originalUrl : ROOT);
+        final String redirectTo = Play.configuration.getProperty(SECURESOCIAL_LOGIN_REDIRECT, ROOT);
+        redirect( originalUrl != null ? originalUrl : redirectTo);
     }
 
     /**


### PR DESCRIPTION
Possibility to configure after login redirect instead just ROOT
constant('/'). There was problem using just '/' when usint apache and
mod_proxy and play. In application.conf, it is possibility to use
securesocial.login.redirect (same as for logout). e.g.
securesocial.logout.redirect=Application.index
securesocial.login.redirect=Application.index
