### PR TITLE
appDependencies not needed for securesocial - causes build break

### DIFF
--- a/samples/java/demo/project/Build.scala
+++ b/samples/java/demo/project/Build.scala
@@ -12,7 +12,7 @@ object ApplicationBuild extends Build {
     )
 
     val secureSocial = PlayProject(
-    	"securesocial2", appVersion, appDependencies, mainLang = SCALA, path = file("modules/securesocial")
+    	"securesocial2", appVersion, Seq(), mainLang = SCALA, path = file("modules/securesocial")
     )
 
     val main = PlayProject(appName, appVersion, appDependencies, mainLang = JAVA).settings(

--- a/samples/scala/demo/project/Build.scala
+++ b/samples/scala/demo/project/Build.scala
@@ -12,7 +12,7 @@ object ApplicationBuild extends Build {
     )
  
     val secureSocial = PlayProject(
-    	appName + "-securesocial", appVersion, appDependencies, mainLang = SCALA, path = file("modules/securesocial")
+    	appName + "-securesocial", appVersion, Seq(), mainLang = SCALA, path = file("modules/securesocial")
     )
 
     val main = PlayProject(appName, appVersion, appDependencies, mainLang = SCALA).settings(


### PR DESCRIPTION
Pass empty Seq() to securesocial, otherwise dependencies defined for the main project will also be loaded for securesocial and resolvers need to be defined twice (in the securesocial project, where the dependency is not needed and in the real project, where it actually is)
