### PR TITLE
prevent infinite redirect on log in when already logged in

### DIFF
--- a/module-code/app/securesocial/controllers/LoginPage.scala
+++ b/module-code/app/securesocial/controllers/LoginPage.scala
@@ -78,9 +78,7 @@ object LoginPage extends Controller
               if ( Logger.isDebugEnabled ) {
                 Logger.debug("User logged in : [" + user + "]")
               }
-              val toUrl = session.get(SecureSocial.ProviderKey).getOrElse(
-                Play.configuration.getString(onLoginGoTo).getOrElse(Root)
-              )
+              val toUrl = Play.configuration.getString(onLoginGoTo).getOrElse(Root)
               Redirect(toUrl).withSession { session +
                 (SecureSocial.UserKey -> user.id.id) +
                 (SecureSocial.ProviderKey -> user.id.providerId) -


### PR DESCRIPTION
The app was infinitely redirecting when logging in twice.

To reproduce:
- start scala sample
- goto .../login page & log in with google OAuth
- login goes fine
- goto .../login page again & try to log in again

Result:
- app keeps redirecting until browser detects loop

This commit fixes the behaviour (but it might have broken something else if it goes to `session.get(SecureSocial.ProviderKey)` for a specific reason). 
Please review.
