### PR TITLE
Prevent NotSerializableException in OAuth1Provider

### DIFF
--- a/module-code/app/securesocial/core/OAuth1Provider.scala
+++ b/module-code/app/securesocial/core/OAuth1Provider.scala
@@ -71,7 +71,7 @@ abstract class OAuth1Provider(application: Application) extends IdentityProvider
           case Right(token) =>
             // the Cache api does not have a remove method.  Just set the cache key and expire it after 1 second for
             // now.
-            Cache.set(cacheKey, Unit, 1)
+            Cache.set(cacheKey, "", 1)
             Right(
               SocialUser(
                 UserId("", providerId), "", None, None, authMethod,


### PR DESCRIPTION
I needed to make this small change to prevent the following exception when using an oauth1 provider:

Execution exception
[NotSerializableException: scala.Unit$]
In .../modules/securesocial/app/securesocial/core/OAuth1Provider.scala at line 74.

Tested with Play 2.0.4.
