### PR TITLE
Fix OAuth1 providers to not clear the session on login

### DIFF
--- a/module-code/app/securesocial/core/OAuth1Provider.scala
+++ b/module-code/app/securesocial/core/OAuth1Provider.scala
@@ -94,7 +94,7 @@ abstract class OAuth1Provider(application: Application) extends IdentityProvider
       service.retrieveRequestToken(callbackUrl) match {
         case Right(accessToken) =>
           val cacheKey = UUID.randomUUID().toString
-          val redirect = Redirect(service.redirectUrl(accessToken.token)).withSession("cacheKey" -> cacheKey)
+          val redirect = Redirect(service.redirectUrl(accessToken.token)).withSession(request.session + ("cacheKey" -> cacheKey))
           Cache.set(cacheKey, accessToken, 600) // set it for 10 minutes, plenty of time to log in
           Left(redirect)
         case Left(e) =>


### PR DESCRIPTION
Hi! Unless there is a reason that the session should be cleared for OAuth1 providers, I recommend this patch to make the behavior consistent with OAuth2 providers.

It will make it so that the Play session is _not_ cleared when a user logs in using an OAuth1 provider.
