### PR TITLE
Fix a RuntimeException in the github provider.

### DIFF
--- a/module-code/app/securesocial/core/providers/GitHubProvider.scala
+++ b/module-code/app/securesocial/core/providers/GitHubProvider.scala
@@ -73,7 +73,7 @@ class GitHubProvider(application: Application) extends OAuth2Provider(applicatio
           }
           case _ => {
             val id = (me \ Id).as[Int]
-            val displayName = (me \ Name).as[String]
+            val displayName = (me \ Name).asOpt[String].getOrElse("")
             val avatarUrl = (me \ AvatarUrl).asOpt[String]
             val email = (me \ Email).asOpt[String].filter( !_.isEmpty )
             user.copy(


### PR DESCRIPTION
The GitHub provider will throw a RuntimeException if the user's name is not in the response.  The name won't be in the response unless the user explicitly sets it in their GitHub public profile settings.  

GitHub does not currently ask for this information at account creation, so it is somewhat likely that new GitHub users will not have their name set.  Once set, the name can be cleared (set to the empty string), but not removed, so this problem can only be able to demonstrated by registering a new GitHub account.
