### PR TITLE
Twitter improvements

### DIFF
--- a/module-code/app/securesocial/core/providers/TwitterProvider.scala
+++ b/module-code/app/securesocial/core/providers/TwitterProvider.scala
@@ -54,7 +54,7 @@ class TwitterProvider(application: Application) extends OAuth1Provider(applicati
 }
 
 object TwitterProvider {
-  val VerifyCredentials = "https://api.twitter.com/1/account/verify_credentials.json"
+  val VerifyCredentials = "https://api.twitter.com/1.1/account/verify_credentials.json"
   val Twitter = "twitter"
   val Id = "id"
   val Name = "name"


### PR DESCRIPTION
Twitter provides two URLs for the avatar, one for http and the other for https.  For consistency with the other providers (which provide https URLs), and because images with https URLs can be embedded in pages served by http without browser warnings (the reverse not being true), this patch causes the twitter provider to use the https avatar URL.

The other patch just switches the endpoint to use Twitter's newer API; supposedly the old API will be unavailable after the first quarter of next year.
