### PR TITLE
Get HTTPS avatar URL in the Facebook provider.

### DIFF
--- a/module-code/app/securesocial/core/providers/FacebookProvider.scala
+++ b/module-code/app/securesocial/core/providers/FacebookProvider.scala
@@ -26,7 +26,7 @@ import play.api.libs.ws.{Response, WS}
  * A Facebook Provider
  */
 class FacebookProvider(application: Application) extends OAuth2Provider(application) {
-  val MeApi = "https://graph.facebook.com/me?fields=name,first_name,last_name,picture,email&access_token="
+  val MeApi = "https://graph.facebook.com/me?fields=name,first_name,last_name,picture,email&return_ssl_resources=1&access_token="
   val Error = "error"
   val Message = "message"
   val Type = "type"


### PR DESCRIPTION
This causes the Facebook provider to get the HTTPS avatar URL so that it can Just Work without browser warnings.
