### PR TITLE
fix wrong linkedin key for getting fullName

### DIFF
--- a/module-code/app/securesocial/core/providers/LinkedInProvider.scala
+++ b/module-code/app/securesocial/core/providers/LinkedInProvider.scala
@@ -84,7 +84,7 @@ object LinkedInProvider {
   val Id = "id"
   val FirstName = "firstName"
   val LastName = "lastName"
-  val FormattedName = "formatted-name"
+  val FormattedName = "formattedName"
   val PictureUrl = "pictureUrl"
 
 }


### PR DESCRIPTION
The fullName isn't working with LinkedIn because the key for getting the "formatted name" in the LinkedIn API is different.
