### PR TITLE
Fixed the error message for invalid token

### DIFF
--- a/module-code/app/securesocial/controllers/Registration.scala
+++ b/module-code/app/securesocial/controllers/Registration.scala
@@ -185,7 +185,7 @@ object Registration extends Controller {
       }
       case _ => {
         val to = if ( isSignUp ) RoutesHelper.startSignUp() else RoutesHelper.startResetPassword()
-        Redirect(to).flashing(Error -> InvalidLink)
+        Redirect(to).flashing(Error -> Messages(InvalidLink))
       }
     }
   }


### PR DESCRIPTION
If you visit the signup page with an invalid token, the flash context says literally, "securesocial.signup.invalidLink" instead of the corresponding line in conf/message.
