### PR TITLE
Allow overriding Registration step redirect targets.

### DIFF
--- a/docs/src/manual/source/guide/configuration.md
+++ b/docs/src/manual/source/guide/configuration.md
@@ -30,13 +30,13 @@ These settings go in the `smtp` section of the `securesocial.conf` file:
 
 - `onLogoutGoTo`: The page where the user is redirected to after logging out.
 
-- `onHandleStartSignUpGoTo`: The page where the user is redirected to after sign up was started (form with email address was submitted/processed)
+- `onStartSignUpGoTo`: The page where the user is redirected to after sign up was started (form with email address was submitted/processed)
 
-- `onHandleSignUpGoTo`: The page where the user is redirected to after sign-up was completed (full sign up form was submitted/processed)
+- `onSignUpGoTo`: The page where the user is redirected to after sign-up was completed (full sign up form was submitted/processed)
 
-- `onHandleStartResetPasswordGoTo`: The page where the user is redirected to after password reset was started (form with email address was submitted/processed)
+- `onStartResetPasswordGoTo`: The page where the user is redirected to after password reset was started (form with email address was submitted/processed)
 
-- `onHandleResetPasswordGoTo`: The page where the user is redirected to after the password was reset (change password form was submitted/processed)
+- `onResetPasswordGoTo`: The page where the user is redirected to after the password was reset (change password form was submitted/processed)
 
 - `ssl`: You can enable SSL for OAuth callbacks, the login, signup and reset password actions of the `UsernamePasswordProvider` and for the cookie used to trace users (you'll want this in production mode).
 

--- a/module-code/app/securesocial/controllers/Registration.scala
+++ b/module-code/app/securesocial/controllers/Registration.scala
@@ -64,13 +64,13 @@ object Registration extends Controller {
   val TokenDuration = Play.current.configuration.getInt(TokenDurationKey).getOrElse(DefaultDuration)
   
   /** The redirect target of the handleStartSignUp action. */
-  val onHandleStartSignUpGoTo = stringConfig("securesocial.onHandleStartSignUpGoTo", RoutesHelper.login().url)
+  val onHandleStartSignUpGoTo = stringConfig("securesocial.onStartSignUpGoTo", RoutesHelper.login().url)
   /** The redirect target of the handleSignUp action. */
-  val onHandleSignUpGoTo = stringConfig("securesocial.onHandleSignUpGoTo", RoutesHelper.login().url)
+  val onHandleSignUpGoTo = stringConfig("securesocial.onSignUpGoTo", RoutesHelper.login().url)
   /** The redirect target of the handleStartResetPassword action. */
-  val onHandleStartResetPasswordGoTo = stringConfig("securesocial.onHandleStartResetPasswordGoTo", RoutesHelper.login().url)
+  val onHandleStartResetPasswordGoTo = stringConfig("securesocial.onStartResetPasswordGoTo", RoutesHelper.login().url)
   /** The redirect target of the handleResetPassword action. */
-  val onHandleResetPasswordGoTo = stringConfig("securesocial.onHandleResetPasswordGoTo", RoutesHelper.login().url)
+  val onHandleResetPasswordGoTo = stringConfig("securesocial.onResetPasswordGoTo", RoutesHelper.login().url)
   
   private def stringConfig(key: String, default: => String) = {
     Play.current.configuration.getString(key).getOrElse(default)

--- a/module-code/conf/securesocial/defaults.conf
+++ b/module-code/conf/securesocial/defaults.conf
@@ -7,10 +7,10 @@
 securesocial {
     onLoginGoTo=/
     onLogoutGoTo=/login
-    onHandleStartSignUpGoTo=/login
-    onHandleSignUpGoTo=/login
-    onHandleStartResetPasswordGoTo=/login
-    onHandleResetPasswordGoTo=/login
+    onStartSignUpGoTo=/login
+    onSignUpGoTo=/login
+    onStartResetPasswordGoTo=/login
+    onResetPasswordGoTo=/login
 
     twitter {
         requestTokenUrl="https://twitter.com/oauth/request_token"


### PR DESCRIPTION
Registration actions like handleStartSignUp etc. redirected to login,
which is not always desirable. To allow users to change this the
Registration object is changed to a class so that it can be used as
a managed controller (which was introduced with play 2.1) and
subclassed by securesocial users.
There's also a Registration companion object, so that the controller
can also be routed as before.
