### PR TITLE
add ability to set extra params to oauth2 url endpoints

### DIFF
--- a/module-code/app/securesocial/core/OAuth2Provider.scala
+++ b/module-code/app/securesocial/core/OAuth2Provider.scala
@@ -24,6 +24,7 @@ import Play.current
 import play.api.mvc.{Results, Result, Request}
 import providers.utils.RoutesHelper
 import play.api.libs.ws.{Response, WS}
+import scala.collection.JavaConversions._
 import scala.concurrent.TimeoutException
 
 /**
@@ -42,7 +43,15 @@ abstract class OAuth2Provider(application: Application) extends IdentityProvider
       clientSecret <- loadProperty(OAuth2Settings.ClientSecret)
     } yield {
       val scope = application.configuration.getString(propertyKey + OAuth2Settings.Scope)
-      OAuth2Settings(authorizationUrl, accessToken, clientId, clientSecret, scope)
+      val authorizationUrlParams: Map[String, String] =
+        application.configuration.getObject(propertyKey + OAuth2Settings.AuthorizationUrlParams).map{ o =>
+          o.unwrapped.toMap.mapValues(_.toString)
+        }.getOrElse(Map())
+      val accessTokenUrlParams: Map[String, String] =
+        application.configuration.getObject(propertyKey + OAuth2Settings.AccessTokenUrlParams).map{ o =>
+          o.unwrapped.toMap.mapValues(_.toString)
+        }.getOrElse(Map())
+      OAuth2Settings(authorizationUrl, accessToken, clientId, clientSecret, scope, authorizationUrlParams, accessTokenUrlParams)
     }
     if ( !result.isDefined ) {
       throwMissingPropertiesException()
@@ -57,7 +66,7 @@ abstract class OAuth2Provider(application: Application) extends IdentityProvider
       OAuth2Constants.GrantType -> Seq(OAuth2Constants.AuthorizationCode),
       OAuth2Constants.Code -> Seq(code),
       OAuth2Constants.RedirectUri -> Seq(RoutesHelper.authenticate(id).absoluteURL(IdentityProvider.sslEnabled))
-    )
+    ) ++ settings.accessTokenUrlParams.mapValues(Seq(_))
     val call = WS.url(settings.accessTokenUrl).post(params)
     try {
       buildInfo(awaitResult(call))
@@ -127,8 +136,9 @@ abstract class OAuth2Provider(application: Application) extends IdentityProvider
           (OAuth2Constants.ResponseType, OAuth2Constants.Code),
           (OAuth2Constants.State, state))
         settings.scope.foreach( s => { params = (OAuth2Constants.Scope, s) :: params })
+        settings.authorizationUrlParams.foreach( e => { params = e :: params })
         val url = settings.authorizationUrl +
-          params.map( p => p._1 + "=" + URLEncoder.encode(p._2, "UTF-8")).mkString("?", "&", "")
+          params.map( p => URLEncoder.encode(p._1, "UTF-8") + "=" + URLEncoder.encode(p._2, "UTF-8")).mkString("?", "&", "")
         if ( Logger.isDebugEnabled ) {
           Logger.debug("[securesocial] authorizationUrl = %s".format(settings.authorizationUrl))
           Logger.debug("[securesocial] redirecting to: [%s]".format(url))
@@ -139,12 +149,15 @@ abstract class OAuth2Provider(application: Application) extends IdentityProvider
 }
 
 case class OAuth2Settings(authorizationUrl: String, accessTokenUrl: String, clientId: String,
-                          clientSecret: String, scope: Option[String]
+                          clientSecret: String, scope: Option[String],
+                          authorizationUrlParams: Map[String, String], accessTokenUrlParams: Map[String, String]
                            )
 
 object OAuth2Settings {
   val AuthorizationUrl = "authorizationUrl"
   val AccessTokenUrl = "accessTokenUrl"
+  val AuthorizationUrlParams = "authorizationUrlParams"
+  val AccessTokenUrlParams = "accessTokenUrlParams"
   val ClientId = "clientId"
   val ClientSecret = "clientSecret"
   val Scope = "scope"


### PR DESCRIPTION
Some OAuth2 identity providers (e.g. Google) use extra, non-OAuth2 request parameters to OAuth2 endpoints in order to alter the flow in various ways.  This patch provides a way to configure extra parameters to be sent to OAuth2 endpoints.  It may also help resolve issue #158.

Two new optional configuration keys are added to OAuth2 identity providers: authorizationUrlParams and accessTokenUrlParams, e.g.:

```
google {
    authorizationUrl="https://accounts.google.com/o/oauth2/auth"
    ...
    authorizationUrlParams {
        access_type=offline
    }
}
```

This patch was created in collaboration with @nascosto.
