### PR TITLE
The DefaultAuthenticatorStore should set the configured idleTimeout.

### DIFF
--- a/module-code/app/securesocial/core/Authenticator.scala
+++ b/module-code/app/securesocial/core/Authenticator.scala
@@ -153,7 +153,7 @@ abstract class AuthenticatorStore(app: Application) extends Plugin {
  */
 class DefaultAuthenticatorStore(app: Application) extends AuthenticatorStore(app) {
   def save(authenticator: Authenticator): Either[Error, Unit] = {
-    Cache.set(authenticator.id,authenticator)
+    Cache.set(authenticator.id,authenticator, Authenticator.idleTimeoutInSeconds)
     Right(())
   }
   def find(id: String): Either[Error, Option[Authenticator]] = {
@@ -193,6 +193,7 @@ object Authenticator {
   lazy val cookieSecure = IdentityProvider.sslEnabled
   lazy val cookieHttpOnly = Play.application.configuration.getBoolean(CookieHttpOnlyKey).getOrElse(DefaultCookieHttpOnly)
   lazy val idleTimeout = Play.application.configuration.getInt(IdleTimeoutKey).getOrElse(DefaultIdleTimeout)
+  lazy val idleTimeoutInSeconds = idleTimeout * 60
   lazy val absoluteTimeout = Play.application.configuration.getInt(AbsoluteTimeoutKey).getOrElse(DefaultAbsoluteTimeout)
   lazy val absoluteTimeoutInSeconds = absoluteTimeout * 60
   lazy val makeTransient = Play.application.configuration.getBoolean(TransientKey).getOrElse(true)


### PR DESCRIPTION
The cache based DefaultAuthenticatorStore does not specify the timeToLive when saving an authenticator. AFAICS this means, that when the authenticator is removed from the cache due to the default cache TTL, the user is logged out, even if the configured idleTimeout is not reached.

With the attached commit the DefaultAuthenticatorStore uses the configured idleTimeout when putting the authenticator into the cache.
Then one can also make use of ehcache's configuration "diskPersistent" to have some kind of durability for user sessions (of course only for single server setup, simplest setups).
