### PR TITLE
Fix ClassCastException on application reload (dev mode) when using Events

### DIFF
--- a/module-code/app/securesocial/core/Events.scala
+++ b/module-code/app/securesocial/core/Events.scala
@@ -83,7 +83,6 @@ abstract class EventListener extends Plugin with Registrable {
  * Helper object to fire events
  */
 object Events {
-  lazy val listeners = Registry.eventListeners.all().toList.map(_._2)
 
   def doFire(list: List[EventListener], event: Event,
              request: RequestHeader, session: Session): Session =
@@ -97,6 +96,7 @@ object Events {
   }
 
   def fire(event: Event)(implicit request: RequestHeader): Option[Session] = {
+    val listeners = Registry.eventListeners.all().toList.map(_._2)
     val result = doFire(listeners, event, request, request.session)
     if ( result == request.session ) None else Some(result)
   }


### PR DESCRIPTION
During development we're seeing ClassCastExceptions like the following
when the application got reloaded (due to some change) and our EventListener
casts the Identity retrieved from event.user() to our custom user class:

```
2013-03-11 12:08:44,701 [error]  application
Unable to log user in. An exception was thrown
java.lang.ClassCastException: model.MyUser cannot be cast to model.MyUser
        at controllers.SecureSocialEventListener.onEvent(SecureSocialEventListener.java:48) ~[classes/:2.1.0]
        at securesocial.core.Events$.doFire(Events.scala:94) ~[securesocial_2.10-master-SNAPSHOT.jar:master-SNAPSHOT]
        at securesocial.core.Events$.fire(Events.scala:100) ~[securesocial_2.10-master-SNAPSHOT.jar:master-SNAPSHOT]
```

This happens because an outdated instance of the EventListener receives
the call - the old instance is still kept in Events.listeners (verified via
debugging/logging in our event listener).

To fix this, the listeners are now retrieved from the Registry on each
Events.fire, so that the actually registered listeners are notified.
