### PR TITLE
do not prevent login on missing google profile info

### DIFF
--- a/module-code/app/securesocial/core/providers/GoogleProvider.scala
+++ b/module-code/app/securesocial/core/providers/GoogleProvider.scala
@@ -56,18 +56,18 @@ class GoogleProvider(application: Application) extends OAuth2Provider(applicatio
           throw new AuthenticationException()
         case _ =>
           val userId = (me \ Id).as[String]
-          val firstName = (me \ GivenName).as[String]
-          val lastName = (me \ FamilyName).as[String]
-          val fullName = (me \ Name).as[String]
+          val firstName = (me \ GivenName).asOpt[String]
+          val lastName = (me \ FamilyName).asOpt[String]
+          val fullName = (me \ Name).asOpt[String]
           val avatarUrl = ( me \ Picture).asOpt[String]
-          val email = ( me \ Email).as[String]
+          val email = ( me \ Email).asOpt[String]
           user.copy(
             id = UserId(userId, id),
-            firstName = firstName,
-            lastName = lastName,
-            fullName = fullName,
+            firstName = firstName.getOrElse(""),
+            lastName = lastName.getOrElse(""),
+            fullName = fullName.getOrElse(""),
             avatarUrl = avatarUrl,
-            email = Some(email)
+            email = email
           )
       }
     } catch {


### PR DESCRIPTION
The [documentation](https://developers.google.com/accounts/docs/OAuth2Login#userinfocall) does not seem to mention it, but I have observed that `given_name` and `family_name` are sometimes not supplied by the userinfo endpoint, resulting in an exception.  Authentication should probably not be prevented due only to missing profile information.
