### PR TITLE
On login/signUp redirect to the referer of the first signup/login reques

### DIFF
--- a/module-code/app/securesocial/controllers/LoginPage.scala
+++ b/module-code/app/securesocial/controllers/LoginPage.scala
@@ -49,8 +49,7 @@ object LoginPage extends Controller
       Redirect( to )
     } else {
       import com.typesafe.plugin._
-      import Play.current
-      Ok(use[TemplatesPlugin].getLoginPage(request, UsernamePasswordProvider.loginForm))
+      SecureSocial.withRefererAsOriginalUrl(Ok(use[TemplatesPlugin].getLoginPage(request, UsernamePasswordProvider.loginForm)))
     }
   }
 

--- a/module-code/app/securesocial/controllers/Registration.scala
+++ b/module-code/app/securesocial/controllers/Registration.scala
@@ -139,7 +139,7 @@ object Registration extends Controller {
    * Starts the sign up process
    */
   def startSignUp = Action { implicit request =>
-    Ok(use[TemplatesPlugin].getStartSignUpPage(request, startForm))
+    SecureSocial.withRefererAsOriginalUrl(Ok(use[TemplatesPlugin].getStartSignUpPage(request, startForm)))
   }
 
   private def createToken(email: String, isSignUp: Boolean): (String, Token) = {

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -23,6 +23,7 @@ import play.api.Logger
 import play.api.libs.json.Json
 import scala.Some
 import play.api.libs.oauth.ServiceInfo
+import play.api.http.HeaderNames
 
 
 /**
@@ -242,6 +243,29 @@ object SecureSocial {
     Registry.providers.get(user.id.providerId) match {
       case Some(p: OAuth1Provider) if p.authMethod == AuthenticationMethod.OAuth1 => Some(p.serviceInfo)
       case _ => None
+    }
+  }
+
+  /**
+   * Saves the referer as original url in the session if it's not yet set.
+   * @param result the result that maybe enhanced with an updated session
+   * @return the result that's returned to the client
+   */
+  def withRefererAsOriginalUrl[A](result: Result)(implicit request: Request[A]): Result = {
+    request.session.get(OriginalUrlKey) match {
+      // If there's already an original url recorded we keep it: e.g. if s.o. goes to
+      // login, switches to signup and goes back to login we want to keep the first referer
+      case Some(_) => result
+      case None => {
+        request.headers.get(HeaderNames.REFERER).map { referer =>
+          // we don't want to use the ful referer, as then we might redirect from https
+          // back to http and loose our session. So let's get the path and query string only
+          val idxFirstSlash = referer.indexOf("/", "https://".length())
+          val refererUri = if (idxFirstSlash < 0) "/" else referer.substring(idxFirstSlash)
+          result.withSession(
+            request.session + (OriginalUrlKey -> refererUri))
+        }.getOrElse(result)
+      }
     }
   }
 }


### PR DESCRIPTION
The referer is saved as original url when the login or signup page is
hit. If there's already an original url saved in the session, this is
not changed (e.g. the user might go to the login page, navigate to
signup and back again to login, then we want to keep the referer of the
first login request). To keep the request scheme/protocol, not the full
referer (including e.g. "http") is saved, but only the path and query
string. Otherwise, the user might be redirected from https back to
http and loose it's session (would not be logged in on http).

This changes the previous behaviour which used the onLoginGoTo property
to redirect the user to on login. This is now only used when no referer
was available.
If s.o. complains about this change one might change the behaviour so
that the referer is only used if no onLoginGoTo is configured.

Closes issue #157
