### PR TITLE
Facebook login error when using the publish_stream scope 

### DIFF
--- a/module-code/app/securesocial/core/providers/FacebookProvider.scala
+++ b/module-code/app/securesocial/core/providers/FacebookProvider.scala
@@ -46,6 +46,7 @@ class FacebookProvider(application: Application) extends OAuth2Provider(applicat
   override protected def buildInfo(response: Response): OAuth2Info = {
     response.body.split("&|=") match {
         case Array(AccessToken, token, Expires, expiresIn) => OAuth2Info(token, None, Some(expiresIn.toInt))
+        case Array(AccessToken, token) => OAuth2Info(token)
         case _ =>
           Logger.error("[securesocial] invalid response format for accessToken")
           throw new AuthenticationException()


### PR DESCRIPTION
I was using the "email,manage_pages,publish_stream" scope and the facebook auth failed on the second login attempt because of the absence of the "expires" parameter on the token response.
This should fix the issue.
Thank you for the great library!
