### PR TITLE
Githubprovider should use user/login, not user/id, for access control to be possible

### DIFF
--- a/module-code/app/securesocial/core/providers/GitHubProvider.scala
+++ b/module-code/app/securesocial/core/providers/GitHubProvider.scala
@@ -34,7 +34,7 @@ class GitHubProvider(application: Application) extends OAuth2Provider(applicatio
   val AccessToken = "access_token"
   val TokenType = "token_type"
   val Message = "message"
-  val Id = "id"
+  val Login = "login"
   val Name = "name"
   val AvatarUrl = "avatar_url"
   val Email = "email"
@@ -68,7 +68,7 @@ class GitHubProvider(application: Application) extends OAuth2Provider(applicatio
           throw new AuthenticationException()
         }
         case _ => {
-          val userId = (me \ Id).as[Int]
+          val userId = (me \ Login).as[String]
           val displayName = (me \ Name).asOpt[String].getOrElse("")
           val avatarUrl = (me \ AvatarUrl).asOpt[String]
           val email = (me \ Email).asOpt[String].filter( !_.isEmpty )


### PR DESCRIPTION
I can't very well create a good access control with the current implementation since with github the user/id is a meaningless integer that nobody knows about their github account without calling github json apis. I can't ask a user to provide that integer because it isn't shown anywhere in the github UI.

In the github API the user/login field contains the github userid. Which is perfect for accesscontrol.

Find attached the proposed change.
