### PR TITLE
Add StreetLend.com to list of sites using SecureSocial

### DIFF
--- a/docs/src/manual/source/index.html.erb
+++ b/docs/src/manual/source/index.html.erb
@@ -89,6 +89,10 @@ title: SecureSocial - Authentication for Play Framework Applications
 	</div>
 
 	<div class="span6">
+		<h4><a href="http://www.streetlend.com/" target="_blank">Streetlend - Helping neighbours to share things</a></h4>
+		<p>Service to help neighbours lend things like ladders, DVDs etc</p>
+		<p class="muted">London, England</p>
+	
 		<h4><a href="https://webservices.io/" target="_blank">WebServices.io</a></h4>
 		<p>Webservices for document conversion and document merging.</p>
 		<p class="muted">Edinburgh, Scotland</p>


### PR DESCRIPTION
StreetLend.com http://www.streetlend.com/ is a website I created to help neighbours lend things to each other. It uses SecureSocial for authentication.
