### PR TITLE
Add OAuth2 provider for LinkedIn

### DIFF
--- a/docs/src/manual/source/guide/getting-started.html.md.erb
+++ b/docs/src/manual/source/guide/getting-started.html.md.erb
@@ -12,7 +12,7 @@ It provides out of the box support for:
 - Facebook (OAuth2)
 - GitHub (OAuth2)
 - Google (OAuth2)
-- LinkedIn (OAuth1)
+- LinkedIn (OAuth1 or OAuth2)
 - Foursquare (OAuth2)
 - Instagram (OAuth2)
 - VK (OAuth2)

--- a/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
+++ b/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2013 Greg Methvin (greg at methvin dot net)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package securesocial.core.providers
+
+import securesocial.core._
+import play.api.libs.oauth.{RequestToken, OAuthCalculator}
+import play.api.libs.ws.WS
+import play.api.{Application, Logger}
+import LinkedInOAuth2Provider._
+
+/**
+ * A LinkedIn Provider (OAuth2)
+ */
+class LinkedInOAuth2Provider(application: Application) extends OAuth2Provider(application) {
+
+  override def id = LinkedInOAuth2Provider.LinkedIn
+
+  override def fillProfile(user: SocialUser): SocialUser = {
+    val accessToken = user.oAuth2Info.get.accessToken
+    val promise = WS.url(LinkedInOAuth2Provider.Api + accessToken).get()
+
+     try {
+       val response = awaitResult(promise)
+       val me = response.json
+       (me \ ErrorCode).asOpt[Int] match {
+         case Some(error) => {
+           val message = (me \ Message).asOpt[String]
+           val requestId = (me \ RequestId).asOpt[String]
+           val timestamp = (me \ Timestamp).asOpt[String]
+           Logger.error(
+             "Error retrieving information from LinkedIn. Error code: %s, requestId: %s, message: %s, timestamp: %s"
+               format(error, message, requestId, timestamp)
+           )
+           throw new AuthenticationException()
+         }
+         case _ => {
+           val userId = (me \ Id).as[String]
+           val firstName = (me \ FirstName).asOpt[String].getOrElse("")
+           val lastName = (me \ LastName).asOpt[String].getOrElse("")
+           val fullName = (me \ FormattedName).asOpt[String].getOrElse("")
+           val avatarUrl = (me \ PictureUrl).asOpt[String]
+
+           SocialUser(user).copy(
+             id = UserId(userId, id),
+             firstName = firstName,
+             lastName = lastName,
+             fullName= fullName,
+             avatarUrl = avatarUrl
+           )
+         }
+       }
+     } catch {
+       case e: Exception => {
+         Logger.error("[securesocial] error retrieving profile information from LinkedIn", e)
+         throw new AuthenticationException()
+       }
+     }
+  }
+}
+
+object LinkedInOAuth2Provider {
+  val Api = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,picture-url)?format=json&oauth2_access_token="
+  val LinkedIn = "linkedin"
+  val ErrorCode = "errorCode"
+  val Message = "message"
+  val RequestId = "requestId"
+  val Timestamp = "timestamp"
+  val Id = "id"
+  val FirstName = "firstName"
+  val LastName = "lastName"
+  val FormattedName = "formattedName"
+  val PictureUrl = "pictureUrl"
+}


### PR DESCRIPTION
This adds support for LinkedIn's OAuth2 authentication, which is what LinkedIn recommends using for all new applications. For backwards compatibility I kept the old LinkedInProvider and created a new LinkedInOAuth2Provider. The ID is still "linkedin" so you can only install one LinkedIn provider at a time.
