### PR TITLE
Added strings to securesocial.conf in demos

### DIFF
--- a/samples/java/demo/conf/securesocial.conf
+++ b/samples/java/demo/conf/securesocial.conf
@@ -50,6 +50,30 @@ securesocial {
 	onLogoutGoTo=/login
 
 	#
+	# Where to redirect the user when he/she starts the signup process.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onStartSignUpGoTo=/login
+	
+	#
+	# Where to redirect the user when he/she signs up.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onSignUpGoTo=/login
+	
+	#
+	# Where to redirect the user when he starts the password reset process.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onStartResetPasswordGoTo=/login
+	
+	#
+	# Where to redirect the user when he resets his/her password.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onResetPasswordGoTo=/login
+
+	#
 	# Enable SSL for oauth callback urls, login/signup/password recovery pages and the authenticator cookie
 	#
 	ssl=false

--- a/samples/scala/demo/conf/securesocial.conf
+++ b/samples/scala/demo/conf/securesocial.conf
@@ -50,6 +50,30 @@ securesocial {
 	onLogoutGoTo=/login
 
 	#
+	# Where to redirect the user when he/she starts the signup process.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onStartSignUpGoTo=/login
+	
+	#
+	# Where to redirect the user when he/she signs up.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onSignUpGoTo=/login
+	
+	#
+	# Where to redirect the user when he starts the password reset process.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onStartResetPasswordGoTo=/login
+	
+	#
+	# Where to redirect the user when he resets his/her password.
+	# If not set SecureSocial will redirect to the login page
+	#
+	#onResetPasswordGoTo=/login
+
+	#
 	# Enable SSL for oauth callback urls, login/signup/password recovery pages and the authenticator cookie
 	#
 	ssl=false


### PR DESCRIPTION
Added some configuration strings to the demos.

onStartSignUpGoTo=/login
onSignUpGoTo=/login
onStartResetPasswordGoTo=/login
onResetPasswordGoTo=/login

This allows users to know how to make custom login
flows without having to dive into the source code.
