### PR TITLE
Fixes example for view customization docs

### DIFF
--- a/docs/src/manual/source/guide/views-customization.md
+++ b/docs/src/manual/source/guide/views-customization.md
@@ -171,6 +171,18 @@ For example, if the custom templates were placed in the `views/custom` directory
 	  def getPasswordChangedNoticeEmail(user: SocialUser)(implicit request: RequestHeader): (Option[Txt], Option[Html]) = {
 	    (None, Some(views.html.custom.mails.passwordChangedNotice(user)))
 	  }
+
+
+	  /**
+	   * Returns the html of the Not Authorized page
+	   *
+	   * @param request the current http request
+	   * @return a String with the text and/or html body for the email
+	   */
+	  def getNotAuthorizedPage[A](implicit request: Request[A]): Html = {
+	     views.html.custom.mails.notAuthorizedPage()
+	  }
+
 	}
 
 


### PR DESCRIPTION
The code example in https://github.com/jaliss/securesocial/blob/master/docs/src/manual/source/guide/views-customization.md contains bugs. It looks like people have been running into issues with this for months.
- Type for application should be play.Application 
- Should be views.html.custom not view.custom.html
- getNotAuthorizedMethod should be implemented otherwise it throws errors
