### PR TITLE
Added Remember Me feature

### DIFF
--- a/module-code/app/securesocial/controllers/TemplatesPlugin.scala
+++ b/module-code/app/securesocial/controllers/TemplatesPlugin.scala
@@ -23,6 +23,7 @@ import securesocial.core.{Identity, SecuredRequest, SocialUser}
 import play.api.data.Form
 import securesocial.controllers.Registration.RegistrationInfo
 import securesocial.controllers.PasswordChange.ChangeInfo
+import securesocial.core.providers.UsernamePasswordProvider.LoginInfo
 
 
 /**
@@ -44,7 +45,7 @@ trait TemplatesPlugin extends Plugin {
    * @tparam A
    * @return
    */
-  def getLoginPage[A](implicit request: Request[A], form: Form[(String, String)], msg: Option[String] = None): Html
+  def getLoginPage[A](implicit request: Request[A], form: Form[LoginInfo], msg: Option[String] = None): Html
 
   /**
    * Returns the html for the signup page
@@ -165,7 +166,7 @@ trait TemplatesPlugin extends Plugin {
  * @param application
  */
 class DefaultTemplatesPlugin(application: Application) extends TemplatesPlugin {
-  override def getLoginPage[A](implicit request: Request[A], form: Form[(String, String)],
+  override def getLoginPage[A](implicit request: Request[A], form: Form[LoginInfo],
                                msg: Option[String] = None): Html =
   {
     securesocial.views.html.login(form, msg)

--- a/module-code/app/securesocial/core/Authenticator.scala
+++ b/module-code/app/securesocial/core/Authenticator.scala
@@ -43,12 +43,14 @@ case class Authenticator(id: String, identityId: IdentityId, creationDate: DateT
    *
    * @return a cookie instance
    */
-  def toCookie: Cookie = {
+ def toCookie(): Cookie = toCookie(None)
+  def toCookie(remeberMe : Option[Boolean]): Cookie = {
     import Authenticator._
     Cookie(
       cookieName,
       id,
-      if ( makeTransient ) Transient else Some(absoluteTimeoutInSeconds),
+      if ( remeberMe.getOrElse(makeTransient) ) Transient else Some(absoluteTimeoutInSeconds),
+
       cookiePath,
       cookieDomain,
       secure = cookieSecure,

--- a/module-code/app/securesocial/views/login.scala.html
+++ b/module-code/app/securesocial/views/login.scala.html
@@ -1,4 +1,4 @@
-@(loginForm: Form[(String,String)], errorMsg: Option[String] = None)(implicit request: RequestHeader)
+@(loginForm: Form[securesocial.core.providers.UsernamePasswordProvider.LoginInfo], errorMsg: Option[String] = None)(implicit request: RequestHeader)
 
 @import helper._
 @import securesocial.core.Registry

--- a/module-code/app/securesocial/views/provider.scala.html
+++ b/module-code/app/securesocial/views/provider.scala.html
@@ -1,4 +1,4 @@
-@(providerId: String, loginForm: Option[Form[(String, String)]] = None)(implicit request: RequestHeader)
+@(providerId: String, loginForm: Option[Form[securesocial.core.providers.UsernamePasswordProvider.LoginInfo]] = None)(implicit request: RequestHeader)
 
 @import securesocial.core.Registry
 @import securesocial.core.IdentityProvider
@@ -40,6 +40,14 @@
                             '_label -> Messages("securesocial.signup.password1"),
                             'class -> "input-xlarge"
                         )
+                        
+                        @if( UsernamePasswordProvider.withRememberMe ) {
+                            @helper.checkbox(
+                                loginForm.get("remember"),
+                                '_label -> Messages("securesocial.login.remember"),
+                                'class -> "input-xlarge"
+                            )
+                        } 
 
                         <div class="form-actions">
                             <button type="submit" class="btn btn-primary">@Messages("securesocial.login.title")</button>

--- a/module-code/conf/messages.zh-CN
+++ b/module-code/conf/messages.zh-CN
@@ -3,6 +3,7 @@ securesocial.appName=Secure Social 2
 
 # Login page
 securesocial.login.title=登录
+securesocial.login.remember=記住我
 securesocial.login.instructions=用你在这里的账号或点击下面这些网站的图标登录
 securesocial.login.accessDenied=你被拒绝访问你的账号。请允许用该账号登录。
 securesocial.login.errorLoggingIn=在你登录时系统出错了，请再试一次。

--- a/samples/scala/demo/conf/securesocial.conf
+++ b/samples/scala/demo/conf/securesocial.conf
@@ -164,6 +164,7 @@ securesocial {
 		# Enable username support, otherwise SecureSocial will use the emails as user names
 		#
 		withUserNameSupport=false
+		withRememberMe = false
 		sendWelcomeEmail=true
 		enableGravatarSupport=true
 		tokenDuration=60


### PR DESCRIPTION
This is a new feature to add remember me feature in login view.

Here's the change log:
- In class `Authenticator` I've changed `toCookie` method signature to accept a new argument which is `rememberCookie` as boolean
- I've rewrote the structure of the login form to accept the `LoginInfo` object instead of accepting `tuple(String, String)`
- Add a new class `case class LoginInfo(username: String, password: String, remember: Option[Boolean])` to be used in the new form `loginFormWithoutRemember` instead of accepting two strings as username and password, so we pass the remember me option along side with the credentials
- Added `lazy val withRememberMe = current.configuration.getBoolean(RememberMe).getOrElse(false)`
- Modify the view to add remember me checkbox at `/views/provider.scala.html`
