### PR TITLE
configurable length of generated id

### DIFF
--- a/module-code/app/securesocial/core/Authenticator.scala
+++ b/module-code/app/securesocial/core/Authenticator.scala
@@ -91,16 +91,24 @@ abstract class IdGenerator(app: Application) extends Plugin {
   def generate: String
 }
 
+object IdGenerator {
+  val GeneratedIdLengthKey = "securesocial.generatedIdLength"
+
+  val DefaultGeneratedIdLength = 256
+}
+
 /**
  * The default id generator
  *
  * @param app A reference to the current app
  */
 class DefaultIdGenerator(app: Application) extends IdGenerator(app) {
+  import IdGenerator._
+
   //todo: this needs improvement, several threads will wait for the synchronized block in SecureRandom.
   // I will probably need a pool of SecureRandom instances.
   val random = new SecureRandom()
-  val IdSizeInBytes = 128
+  val IdSizeInBytes = Play.application.configuration.getInt(GeneratedIdLengthKey).getOrElse(DefaultGeneratedIdLength) / 2
 
   /**
    * Generates a new id using SecureRandom

--- a/samples/java/demo/conf/securesocial.conf
+++ b/samples/java/demo/conf/securesocial.conf
@@ -38,6 +38,17 @@ securesocial {
         #
         #customCssPath="your path"
 
+        #
+        # How long will be generated user id (this identifiers will be used for example as cache key
+        # in DefaultAuthenticatorStore).
+        #
+        # Default value is 256 characters (128 bytes).
+        #
+        # You should set generatedIdLength to 250 (minus memcached.namespace length (if set to any)) if you want to use
+        # secure social plugin with Memcached as a Cache API implementation.
+        #
+        #generatedIdLength=256
+
 	#
 	# Where to redirect the user if SecureSocial can't figure that out from
 	# the request that led the use to the login page

--- a/samples/scala/demo/conf/securesocial.conf
+++ b/samples/scala/demo/conf/securesocial.conf
@@ -38,6 +38,17 @@ securesocial {
         #
         #customCssPath="your path"
 
+        #
+        # How long will be generated user id (this identifiers will be used for example as cache key
+        # in DefaultAuthenticatorStore).
+        #
+        # Default value is 256 characters (128 bytes).
+        #
+        # You should set generatedIdLength to 250 (minus memcached.namespace length (if set to any)) if you want to use
+        # secure social plugin with Memcached as a Cache API implementation.
+        #
+        #generatedIdLength=256
+
 	#
 	# Where to redirect the user if SecureSocial can't figure that out from
 	# the request that led the use to the login page


### PR DESCRIPTION
As I mentioned earlier in #259 there is a problem with generated id legth and Cache API implementation provider other than Ehcache (in my case - it's memcached).

I think adding the config parameter with fallback to a value currently used in DefaultIdGenerator will be more practical and elegant - it would be useful for every cache implementation which has any key-length limitations.
