### PR TITLE
Handle multiple asset routes properly in RoutesHelper (fixes #301)

### DIFF
--- a/module-code/app/securesocial/core/providers/utils/RoutesHelper.scala
+++ b/module-code/app/securesocial/core/providers/utils/RoutesHelper.scala
@@ -111,7 +111,7 @@ object RoutesHelper {
       reverseAssets.asInstanceOf[ReverseAssets].at(file)
     } catch { case _: NoSuchMethodException => try {
       if( Logger.isDebugEnabled && !assetsPathLogged ) {
-        Logger.debug(s"[securesocial] multiple asset routes founding, retrying using path `$assetsPath`")
+        Logger.debug(s"[securesocial] multiple asset routes found, retrying using path `$assetsPath`")
         assetsPathLogged = true
       }
 


### PR DESCRIPTION
Changes RoutesHelper to handle the case of multiple asset routes, when
the ReverseAssets controller needs a path to be specified on `at()`
calls to distinguish among them. Introduces a `securesocial.asssetsPath`
configuration entry to specify the path if necessary (default is
`/public`). Fixes #301.
