### PR TITLE
Removing the second encoding step so that the params dont get encoded tw...

### DIFF
--- a/module-code/app/securesocial/core/OAuth2Provider.scala
+++ b/module-code/app/securesocial/core/OAuth2Provider.scala
@@ -128,7 +128,7 @@ abstract class OAuth2Provider(application: Application, jsonResponse: Boolean = 
           (OAuth2Constants.State, state))
         settings.scope.foreach( s => { params = (OAuth2Constants.Scope, URLEncoder.encode(s, "UTF-8")) :: params })
         val url = settings.authorizationUrl +
-          params.map( p => p._1 + "=" + URLEncoder.encode(p._2, "UTF-8")).mkString("?", "&", "")
+          params.map( p => p._1 + "=" + p._2).mkString("?", "&", "")
         if ( Logger.isDebugEnabled ) {
           Logger.debug("[securesocial] authorizationUrl = %s".format(settings.authorizationUrl))
           Logger.debug("[securesocial] redirecting to: [%s]".format(url))


### PR DESCRIPTION
Removing the second encoding step so that the params dont get encoded twice.
This caused errors with the scopes of the provides.

Related to issue 308
