### PR TITLE
Add onPasswordChangeGoTo option

### DIFF
--- a/docs/src/manual/source/guide/configuration.md
+++ b/docs/src/manual/source/guide/configuration.md
@@ -36,7 +36,9 @@ These settings go in the `smtp` section of the `securesocial.conf` file:
 
 - `onStartResetPasswordGoTo`: The page where the user is redirected to after password reset was started (form with email address was submitted/processed)
 
-- `onResetPasswordGoTo`: The page where the user is redirected to after the password was reset (change password form was submitted/processed)
+- `onResetPasswordGoTo`: The page where the user is redirected to after the password was reset (reset password form was submitted/processed)
+
+- `onPasswordChangeGoTo`: The page where the user is redirected to after the password was changed (change password form was submitted/processed)
 
 - `ssl`: You can enable SSL for OAuth callbacks, the login, signup and reset password actions of the `UsernamePasswordProvider` and for the cookie used to trace users (you'll want this in production mode).
 

--- a/module-code/app/securesocial/controllers/PasswordChange.scala
+++ b/module-code/app/securesocial/controllers/PasswordChange.scala
@@ -40,6 +40,15 @@ object PasswordChange extends Controller with SecureSocial {
   val Success = "success"
   val OkMessage = "securesocial.passwordChange.ok"
 
+  /**
+   * The property that specifies the page the user is redirected to after changing the password.
+   */
+  val onPasswordChangeGoTo = "securesocial.onPasswordChangeGoTo"
+
+  /** The redirect target of the handlePasswordChange action. */
+  def onHandlePasswordChangeGoTo = Play.current.configuration.getString(onPasswordChangeGoTo).getOrElse(
+    RoutesHelper.changePasswordPage().url
+  )
 
   case class ChangeInfo(currentPassword: String, newPassword: String)
 
@@ -86,7 +95,7 @@ object PasswordChange extends Controller with SecureSocial {
           val newPasswordInfo = use[PasswordHasher].hash(info.newPassword)
           val u = UserService.save( SocialUser(request.user).copy( passwordInfo = Some(newPasswordInfo)) )
           Mailer.sendPasswordChangedNotice(u)(request)
-          val result = Redirect(RoutesHelper.changePasswordPage()).flashing(Success -> Messages(OkMessage))
+          val result = Redirect(onHandlePasswordChangeGoTo).flashing(Success -> Messages(OkMessage))
           Events.fire(new PasswordChangeEvent(u))(request).map( result.withSession(_)).getOrElse(result)
         }
       )

--- a/module-code/conf/securesocial/defaults.conf
+++ b/module-code/conf/securesocial/defaults.conf
@@ -11,6 +11,7 @@ securesocial {
     onSignUpGoTo=/login
     onStartResetPasswordGoTo=/login
     onResetPasswordGoTo=/login
+    onPasswordChangeGoTo=/password
 
     twitter {
         requestTokenUrl="https://twitter.com/oauth/request_token"

--- a/samples/java/demo/conf/securesocial.conf
+++ b/samples/java/demo/conf/securesocial.conf
@@ -74,6 +74,12 @@ securesocial {
 	#onResetPasswordGoTo=/login
 
 	#
+	# Where to redirect the user when he changes his/her password.
+	# If not set SecureSocial will redirect to the password change page
+	#
+	#onPasswordChangeGoTo=/password
+
+	#
 	# Enable SSL for oauth callback urls, login/signup/password recovery pages and the authenticator cookie
 	#
 	ssl=false

--- a/samples/scala/demo/conf/securesocial.conf
+++ b/samples/scala/demo/conf/securesocial.conf
@@ -74,6 +74,12 @@ securesocial {
 	#onResetPasswordGoTo=/login
 
 	#
+	# Where to redirect the user when he changes his/her password.
+	# If not set SecureSocial will redirect to the password change page
+	#
+	#onPasswordChangeGoTo=/password
+
+	#
 	# Enable SSL for oauth callback urls, login/signup/password recovery pages and the authenticator cookie
 	#
 	ssl=false


### PR DESCRIPTION
Adds the new, optional 'securesocial.onPasswordChangeGoTo'
configuration property to allow the developer to set which page
the Password Change form should redirect to.

If not set, it preserves the current default option of staying in the
Password Change page.

This option is similar to existing options such as onSignUpGoTo and
onResetPasswordGoTo.
