### PR TITLE
#124 Add test helpers for unit and integration testing of securesocial controllers

### DIFF
--- a/samples/scala/demo/project/Build.scala
+++ b/samples/scala/demo/project/Build.scala
@@ -8,7 +8,8 @@ object ApplicationBuild extends Build {
     val appVersion      = "1.0"
 
     val appDependencies = Seq(
-	"ws.securesocial" %% "securesocial" % "master-SNAPSHOT"
+	    "ws.securesocial" %% "securesocial" % "master-SNAPSHOT",
+      "ws.securesocial" %% "ss-testkit" % "master-SNAPSHOT" % "test"
     )
     val main = play.Project(appName, appVersion, appDependencies).settings(
       resolvers += Resolver.sonatypeRepo("snapshots")

--- a/samples/scala/demo/test/ApplicationScenario.scala
+++ b/samples/scala/demo/test/ApplicationScenario.scala
@@ -1,0 +1,14 @@
+import play.api.test.{FakeRequest, WithApplication, FakeApplication, PlaySpecification}
+
+class ApplicationScenario  extends PlaySpecification {
+  def app = FakeApplication(additionalPlugins = Seq("securesocial.testkit.AlwaysValidIdentityProvider"))
+  "A logged in user can view the index" in new WithApplication(app) {
+    //Given
+    val creds1 = cookies(route(FakeRequest(POST, "/authenticate/naive").withTextBody("user")).get)
+    //When
+    val Some(response)=route(FakeRequest(GET, "/").withCookies(creds1.get("id").get))
+
+    //Then
+    status(response) must equalTo(OK)
+  }
+}

--- a/samples/scala/demo/test/ApplicationSpec.scala
+++ b/samples/scala/demo/test/ApplicationSpec.scala
@@ -1,0 +1,22 @@
+import controllers.Application
+import org.specs2.matcher.ShouldMatchers
+import play.api.http.HeaderNames
+import play.api.mvc.{Request, AnyContent}
+import play.api.test.{PlaySpecification, FakeApplication, FakeRequest}
+import securesocial.testkit.WithLoggedUser
+
+class ApplicationSpec extends PlaySpecification with ShouldMatchers {
+  import WithLoggedUser._
+  def minimalApp = FakeApplication(withoutPlugins=excludedPlugins,additionalPlugins = includedPlugins)
+  "Access secured index " in new WithLoggedUser(minimalApp) {
+
+    val req: Request[AnyContent] = FakeRequest().
+      withHeaders((HeaderNames.CONTENT_TYPE, "application/x-www-form-urlencoded")).
+      withCookies(cookie) // Fake cookie from the WithloggedUser trait
+
+    val result = Application.index.apply(req)
+
+    val actual: Int= status(result)
+    actual must be equalTo OK
+  }
+}

--- a/test-kit/project/Build.scala
+++ b/test-kit/project/Build.scala
@@ -1,0 +1,21 @@
+import sbt._
+import Keys._
+
+object ApplicationBuild extends Build {
+
+    val appName         = "ss-testkit"
+    val appVersion      = "master-SNAPSHOT"
+    val appOrganization    = "ws.securesocial"
+    val dependencies = Seq(
+	    "ws.securesocial" %% "securesocial" % "master-SNAPSHOT",
+      "org.scalacheck" %% "scalacheck" % "1.11.1",
+      "com.typesafe.play" %% "play-test" % "2.2.0",
+      "org.mockito" % "mockito-all" % "1.9.5"
+  )
+    val main = sbt.Project(appName, file(".") ).settings(
+      resolvers += Resolver.sonatypeRepo("snapshots")
+    , libraryDependencies ++= dependencies
+    , version := appVersion
+    , organization := appOrganization
+    )
+}

--- a/test-kit/project/build.properties
+++ b/test-kit/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.0

--- a/test-kit/src/main/scala/securesocial/testkit/AlwaysValidIdentityProvider.scala
+++ b/test-kit/src/main/scala/securesocial/testkit/AlwaysValidIdentityProvider.scala
@@ -1,0 +1,25 @@
+package securesocial.testkit
+
+import play.api.Logger
+import securesocial.core._
+import play.api.mvc.{Result, Request}
+import securesocial.core.IdentityId
+
+class AlwaysValidIdentityProvider(app:play.api.Application) extends IdentityProvider(app){
+  val logger = Logger("securesocial.stubs.AlwaysValidIdentityProvider")
+  def authMethod: AuthenticationMethod = AuthenticationMethod("naive")
+
+
+  override def doAuth()(implicit request: Request[play.api.mvc.AnyContent]): Either[Result, SocialUser] ={
+    val userId = request.body.toString
+    val r =Right(SocialUserGenerator.socialUserGen(IdentityId(userId, id), authMethod).sample.get)
+    r
+  }
+
+
+  def fillProfile(user: SocialUser): SocialUser = {
+    user
+  }
+
+  def id: String = "naive"
+}

--- a/test-kit/src/main/scala/securesocial/testkit/FakeAuthenticatorStore.scala
+++ b/test-kit/src/main/scala/securesocial/testkit/FakeAuthenticatorStore.scala
@@ -1,0 +1,19 @@
+package securesocial.testkit
+
+import securesocial.core.{Authenticator, AuthenticatorStore}
+import play.api.Application
+
+class FakeAuthenticatorStore(app:Application) extends AuthenticatorStore(app) {
+  var authenticator:Option[Authenticator] = None
+  def save(authenticator: Authenticator): Either[Error, Unit] = {
+    this.authenticator=Some(authenticator)
+    Right()
+  }
+  def find(id: String): Either[Error, Option[Authenticator]] = {
+    Some(authenticator.filter(_.id == id)).toRight(new Error("no such authenticator"))
+  }
+  def delete(id: String): Either[Error, Unit] = {
+    this.authenticator=None
+    Right()
+  }
+}

--- a/test-kit/src/main/scala/securesocial/testkit/SocialUserGenerator.scala
+++ b/test-kit/src/main/scala/securesocial/testkit/SocialUserGenerator.scala
@@ -1,0 +1,31 @@
+package securesocial.testkit
+
+import securesocial.core.{SocialUser, AuthenticationMethod, IdentityId}
+import org.scalacheck.Gen
+
+object SocialUserGenerator {
+  val nameGen = for {
+    head <- Gen.alphaUpperChar
+    size<- Gen.choose(1,10)
+    tail <- Gen.listOfN(size,Gen.alphaLowerChar)
+  } yield (head +: tail).mkString("")
+
+  def identityIdGen = for{
+    pid <- nameGen
+    uid <- nameGen
+  } yield IdentityId(uid, pid)
+
+  def identityId = identityIdGen.sample.get
+
+  def authMethodGen = Gen.oneOf(AuthenticationMethod.OAuth1,AuthenticationMethod.OAuth2,AuthenticationMethod.OpenId,AuthenticationMethod.UserPassword)
+
+  def authMethod = authMethodGen.sample.get
+
+  def socialUserGen(id:IdentityId=identityId,authMethod: AuthenticationMethod=authMethod)= for{
+    firstName <- nameGen
+    lastName <- nameGen
+    email = s"${firstName.head}.$lastName@example.com"
+  }yield SocialUser(id, firstName, lastName, s"$firstName $lastName",Some(email),None, authMethod,None, None, None)
+
+  def socialUser(id:IdentityId=identityId,authMethod: AuthenticationMethod=authMethod)=socialUserGen(id, authMethod).sample.get
+}

--- a/test-kit/src/main/scala/securesocial/testkit/WithLoggedUser.scala
+++ b/test-kit/src/main/scala/securesocial/testkit/WithLoggedUser.scala
@@ -1,0 +1,31 @@
+package securesocial.testkit
+
+import securesocial.core.{Authenticator, Identity, UserService}
+import org.specs2.execute.{Result, AsResult}
+import play.api.test.{WithApplication, FakeApplication}
+import org.specs2.mock.Mockito
+
+abstract class WithLoggedUser(override val app: FakeApplication = FakeApplication(),val identity:Option[Identity]=None) extends WithApplication(app) with Mockito {
+
+  lazy val user = identity getOrElse SocialUserGenerator.socialUser()
+  lazy val mockUserService=mock[UserService]
+
+  def cookie=Authenticator.create(user) match {
+    case Right(authenticator) => authenticator.toCookie
+    case _ => throw new IllegalArgumentException("Your FakeApplication _must_ configure a working AuthenticatorStore")
+  }
+
+  override def around[T: AsResult](t: =>T): Result = super.around {
+    mockUserService.find(user.identityId) returns Some(user)
+    UserService.setService(mockUserService)
+    t
+  }
+}
+
+object WithLoggedUser{
+  val excludedPlugins = List( "securesocial.core.DefaultAuthenticatorStore" )
+  val includedPlugins = List( "securesocial.testkit.FakeAuthenticatorStore" )
+  def minimalApp = FakeApplication(withoutPlugins=excludedPlugins,additionalPlugins = includedPlugins)
+}
+
+


### PR DESCRIPTION
I created a securesocial testkit project which is to be included with scope test by projects using securesocial. 
The testkit enables the testing code I described in #124 and its use is demonstrated in the scala sample.

Test helper classes and objects are in test-kit/src/main/scala/securesocial/testkit
Example specifications are in 
samples/scala/demo/test/ApplicationSpec.scala
samples/scala/demo/test/ApplicationScenario.scala

The first one demonstrates unit testing a securedAction, the second one is an integration test against the same action.

I have followed the same versioning convention as was used by the core project.

cheers
jean
