### PR TITLE
hebrew message: was utf-8, now utf-8 without bom

### DIFF
--- a/module-code/conf/messages.he
+++ b/module-code/conf/messages.he
@@ -1,4 +1,4 @@
-﻿# App name
+# App name
 securesocial.appName=SecureSocial 2
 
 # Login page


### PR DESCRIPTION
Cleanup of 'compilation error string matching regex z' expected but ' found' exception when using Hebrew translations messages.
