### PR TITLE
LinkedInOAuth2Provider: retrieve email address and add sample configuration

### DIFF
--- a/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
+++ b/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
@@ -53,13 +53,15 @@ class LinkedInOAuth2Provider(application: Application) extends OAuth2Provider(ap
            val lastName = (me \ LastName).asOpt[String].getOrElse("")
            val fullName = (me \ FormattedName).asOpt[String].getOrElse("")
            val avatarUrl = (me \ PictureUrl).asOpt[String]
+           val emailAddress = (me \ EmailAddress).asOpt[String]
 
            SocialUser(user).copy(
              identityId = IdentityId(userId, id),
              firstName = firstName,
              lastName = lastName,
              fullName= fullName,
-             avatarUrl = avatarUrl
+             avatarUrl = avatarUrl,
+             email = emailAddress
            )
          }
        }
@@ -73,7 +75,7 @@ class LinkedInOAuth2Provider(application: Application) extends OAuth2Provider(ap
 }
 
 object LinkedInOAuth2Provider {
-  val Api = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,picture-url)?format=json&oauth2_access_token="
+  val Api = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,formatted-name,picture-url,email-address)?format=json&oauth2_access_token="
   val LinkedIn = "linkedin"
   val ErrorCode = "errorCode"
   val Message = "message"
@@ -84,4 +86,5 @@ object LinkedInOAuth2Provider {
   val LastName = "lastName"
   val FormattedName = "formattedName"
   val PictureUrl = "pictureUrl"
+  val EmailAddress = "emailAddress"
 }

--- a/samples/scala/demo/conf/securesocial.conf
+++ b/samples/scala/demo/conf/securesocial.conf
@@ -153,6 +153,15 @@ securesocial {
 		consumerSecret=your_consumer_secret
 	}
 
+	# LinkedIn OAuth2 sample configuration
+	# Change line in play.plugins from securesocial.core.providers.LinkedInProvider to securesocial.core.providers.LinkedInOAuth2Provider
+	#linkedin {
+	#	authorizationUrl="https://www.linkedin.com/uas/oauth2/authorization"
+	#	accessTokenUrl="https://www.linkedin.com/uas/oauth2/accessToken"
+	#	clientId=your_client_id
+	#	clientSecret=your_client_secret
+	#}
+
 	github {
 		authorizationUrl="https://github.com/login/oauth/authorize"
 		accessTokenUrl="https://github.com/login/oauth/access_token"


### PR DESCRIPTION
This pull request allows retrieving email address from LinkedIn when using OAuth2 provider, as it was done in PR #237 for OAuth1.
A sample configuration for using LinkedInOAuth2Provider has also been added.
