### PR TITLE
Store Twitter screen_name in user object

### DIFF
--- a/module-code/app/securesocial/core/providers/TwitterProvider.scala
+++ b/module-code/app/securesocial/core/providers/TwitterProvider.scala
@@ -42,7 +42,8 @@ class TwitterProvider(application: Application) extends OAuth1Provider(applicati
       val userId = (me \ Id).as[String]
       val name = (me \ Name).as[String]
       val profileImage = (me \ ProfileImage).asOpt[String]
-      user.copy(identityId = IdentityId(userId, id), fullName = name, avatarUrl = profileImage)
+      val screenName = (me \ ScreenName).as[String]
+      user.copy(identityId = IdentityId(userId, id), firstName = screenName, fullName = name, avatarUrl = profileImage)
 
     } catch {
       case e: Exception => {


### PR DESCRIPTION
Twitter supports a screen_name and a (full) name. The former was not exported
via the SocialUser class. We now misuse the firstName field to store the
screen_name.
