### PR TITLE
Default the play version to 2.2.2

### DIFF
--- a/module-code/project/plugins.sbt
+++ b/module-code/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.2.2"))
 
 // PGP signing
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")


### PR DESCRIPTION
This fixes a NullPointerException in "sbt stage" which is used e.g.
by Heroku to deploy Play applications.
