### PR TITLE
Remove Registration.createToken private modifier

### DIFF
--- a/module-code/app/securesocial/controllers/Registration.scala
+++ b/module-code/app/securesocial/controllers/Registration.scala
@@ -147,7 +147,7 @@ object Registration extends Controller {
     else NotFound(views.html.defaultpages.notFound.render(request, None))
   }
 
-  private def createToken(email: String, isSignUp: Boolean): (String, Token) = {
+  def createToken(email: String, isSignUp: Boolean): (String, Token) = {
     val uuid = UUID.randomUUID().toString
     val now = DateTime.now
 


### PR DESCRIPTION
I have a use case of your plugin where I had to copy past the controllers.Registration.createToken method because of it's private modifier, it would be nice to have it public :).

[This](https://github.com/SlickChair/SlickChair/blob/master/app/controllers/LoginWrapper.scala#L76) is the code I'm referring to. What I'm doing here is to use a single form to handle login, creation of email accounts and "forgot password". I only care about having verified emails of the users, and in this context I don't need to make the traditional sign up/sign separation.
