### PR TITLE
Propagate implicit lang parameter from mailer to mail templates.

### DIFF
--- a/module-code/app/securesocial/controllers/PasswordChange.scala
+++ b/module-code/app/securesocial/controllers/PasswordChange.scala
@@ -82,14 +82,14 @@ object PasswordChange extends Controller with SecureSocial {
 
   def page = SecuredAction { implicit request =>
     execute { (request: SecuredRequest[AnyContent], form: Form[ChangeInfo]) =>
-      Ok(use[TemplatesPlugin].getPasswordChangePage(form)(request))
+      Ok(use[TemplatesPlugin].getPasswordChangePage(form)(request, lang(request)))
     }
   }
 
   def handlePasswordChange = SecuredAction { implicit request =>
     execute { (request: SecuredRequest[AnyContent], form: Form[ChangeInfo]) =>
       form.bindFromRequest()(request).fold (
-        errors => BadRequest(use[TemplatesPlugin].getPasswordChangePage(errors)(request)),
+        errors => BadRequest(use[TemplatesPlugin].getPasswordChangePage(errors)(request, lang(request))),
         info =>  {
           import scala.language.reflectiveCalls
           val newPasswordInfo = Registry.hashers.currentHasher.hash(info.newPassword)

--- a/module-code/app/securesocial/controllers/TemplatesPlugin.scala
+++ b/module-code/app/securesocial/controllers/TemplatesPlugin.scala
@@ -23,6 +23,7 @@ import securesocial.core.{Identity, SecuredRequest}
 import play.api.data.Form
 import securesocial.controllers.Registration.RegistrationInfo
 import securesocial.controllers.PasswordChange.ChangeInfo
+import play.api.i18n.Lang
 
 
 /**
@@ -43,7 +44,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request
    * @return
    */
-  def getLoginPage(form: Form[(String, String)], msg: Option[String] = None)(implicit request: Request[AnyContent]): Html
+  def getLoginPage(form: Form[(String, String)], msg: Option[String] = None)(implicit request: Request[AnyContent], lang:Lang): Html
 
   /**
    * Returns the html for the signup page
@@ -51,7 +52,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request
    * @return
    */
-  def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[AnyContent]): Html
+  def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[AnyContent], lang:Lang): Html
 
   /**
    * Returns the html for the start signup page
@@ -59,7 +60,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request
    * @return
    */
-  def getStartSignUpPage(form: Form[String])(implicit request: Request[AnyContent]): Html
+  def getStartSignUpPage(form: Form[String])(implicit request: Request[AnyContent], lang:Lang): Html
 
   /**
    * Returns the html for the reset password page
@@ -67,7 +68,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request
    * @return
    */
-  def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[AnyContent]): Html
+  def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[AnyContent], lang:Lang): Html
 
   /**
    * Returns the html for the start reset page
@@ -75,7 +76,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request
    * @return
    */
-  def getStartResetPasswordPage(form: Form[String])(implicit request: Request[AnyContent]): Html
+  def getStartResetPasswordPage(form: Form[String])(implicit request: Request[AnyContent], lang:Lang): Html
 
   /**
    * Returns the html for the change password page
@@ -84,7 +85,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param form
    * @return
    */
-  def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: SecuredRequest[AnyContent]): Html
+  def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: SecuredRequest[AnyContent], lang:Lang): Html
 
   /**
    * Returns the html for the not authorized page
@@ -92,7 +93,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request
    * @return
    */
-  def getNotAuthorizedPage(implicit request: Request[AnyContent]): Html
+  def getNotAuthorizedPage(implicit request: Request[AnyContent], lang:Lang): Html
 
   /**
    * Returns the email sent when a user starts the sign up process
@@ -101,7 +102,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getSignUpEmail(token: String)(implicit request: RequestHeader): (Option[Txt], Option[Html])
+  def getSignUpEmail(token: String)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent when the user is already registered
@@ -110,7 +111,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request the current request
    * @return a tuple with the text and/or html body for the email
    */
-  def getAlreadyRegisteredEmail(user: Identity)(implicit request: RequestHeader): (Option[Txt], Option[Html])
+  def getAlreadyRegisteredEmail(user: Identity)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the welcome email sent when the user finished the sign up process
@@ -119,7 +120,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request the current request
    * @return a String with the text and/or html body for the email
    */
-  def getWelcomeEmail(user: Identity)(implicit request: RequestHeader): (Option[Txt], Option[Html])
+  def getWelcomeEmail(user: Identity)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent when a user tries to reset the password but there is no account for
@@ -128,7 +129,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request the current request
    * @return a String with the text and/or html body for the email
    */
-  def getUnknownEmailNotice()(implicit request: RequestHeader): (Option[Txt], Option[Html])
+  def getUnknownEmailNotice()(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent to the user to reset the password
@@ -138,7 +139,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getSendPasswordResetEmail(user: Identity, token: String)(implicit request: RequestHeader): (Option[Txt], Option[Html])
+  def getSendPasswordResetEmail(user: Identity, token: String)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent as a confirmation of a password change
@@ -147,7 +148,7 @@ trait TemplatesPlugin extends Plugin  with Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getPasswordChangedNoticeEmail(user: Identity)(implicit request: RequestHeader): (Option[Txt], Option[Html])
+  def getPasswordChangedNoticeEmail(user: Identity)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html])
 
 }
 
@@ -159,56 +160,56 @@ trait TemplatesPlugin extends Plugin  with Controller {
  */
 class DefaultTemplatesPlugin(application: Application) extends TemplatesPlugin {
   override def getLoginPage(form: Form[(String, String)],
-                               msg: Option[String] = None)(implicit request: Request[AnyContent]): Html =
+                               msg: Option[String] = None)(implicit request: Request[AnyContent], lang:Lang): Html =
   {
     securesocial.views.html.login(form, msg)
   }
 
-  override def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[AnyContent]): Html = {
+  override def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[AnyContent], lang:Lang): Html = {
     securesocial.views.html.Registration.signUp(form, token)
   }
 
-  override def getStartSignUpPage(form: Form[String])(implicit request: Request[AnyContent]): Html = {
+  override def getStartSignUpPage(form: Form[String])(implicit request: Request[AnyContent], lang:Lang): Html = {
     securesocial.views.html.Registration.startSignUp(form)
   }
 
-  override def getStartResetPasswordPage(form: Form[String])(implicit request: Request[AnyContent]): Html = {
+  override def getStartResetPasswordPage(form: Form[String])(implicit request: Request[AnyContent], lang:Lang): Html = {
     securesocial.views.html.Registration.startResetPassword(form)
   }
 
-  override def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[AnyContent]): Html = {
+  override def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[AnyContent], lang:Lang): Html = {
     securesocial.views.html.Registration.resetPasswordPage(form, token)
   }
 
-  override def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: SecuredRequest[AnyContent]):Html = {
+  override def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: SecuredRequest[AnyContent], lang:Lang):Html = {
     securesocial.views.html.passwordChange(form)
   }
 
-  def getNotAuthorizedPage(implicit request: Request[AnyContent]): Html = {
+  def getNotAuthorizedPage(implicit request: Request[AnyContent], lang:Lang): Html = {
     securesocial.views.html.notAuthorized()
   }
 
-  def getSignUpEmail(token: String)(implicit request: RequestHeader): (Option[Txt], Option[Html]) = {
+  def getSignUpEmail(token: String)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html]) = {
     (None, Some(securesocial.views.html.mails.signUpEmail(token)))
   }
 
-  def getAlreadyRegisteredEmail(user: Identity)(implicit request: RequestHeader): (Option[Txt], Option[Html]) = {
+  def getAlreadyRegisteredEmail(user: Identity)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html]) = {
     (None, Some(securesocial.views.html.mails.alreadyRegisteredEmail(user)))
   }
 
-  def getWelcomeEmail(user: Identity)(implicit request: RequestHeader): (Option[Txt], Option[Html]) = {
+  def getWelcomeEmail(user: Identity)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html]) = {
     (None, Some(securesocial.views.html.mails.welcomeEmail(user)))
   }
 
-  def getUnknownEmailNotice()(implicit request: RequestHeader): (Option[Txt], Option[Html]) = {
+  def getUnknownEmailNotice()(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html]) = {
     (None, Some(securesocial.views.html.mails.unknownEmailNotice()))
   }
 
-  def getSendPasswordResetEmail(user: Identity, token: String)(implicit request: RequestHeader): (Option[Txt], Option[Html]) = {
+  def getSendPasswordResetEmail(user: Identity, token: String)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html]) = {
     (None, Some(securesocial.views.html.mails.passwordResetEmail(user, token)))
   }
 
-  def getPasswordChangedNoticeEmail(user: Identity)(implicit request: RequestHeader): (Option[Txt], Option[Html]) = {
+  def getPasswordChangedNoticeEmail(user: Identity)(implicit request: RequestHeader, lang:Lang): (Option[Txt], Option[Html]) = {
     (None, Some(securesocial.views.html.mails.passwordChangedNotice(user)))
   }
 }


### PR DESCRIPTION
The mailer can be called with an arbitrary `lang` parameter, which is not necessarily derived from the requestheader For instance, an application can store a user's language preference so he sees the application in his favorite language event if he is not on his own computer.
