### PR TITLE
A logged in user should be able to change password

### DIFF
--- a/module-code/app/securesocial/controllers/PasswordChange.scala
+++ b/module-code/app/securesocial/controllers/PasswordChange.scala
@@ -72,12 +72,12 @@ object PasswordChange extends Controller with SecureSocial {
       )((currentPassword, newPassword) => ChangeInfo(currentPassword, newPassword._1))
         ((changeInfo: ChangeInfo) => Some("", ("", "")))
     )
-
-    if ( request.user.authMethod != AuthenticationMethod.UserPassword) {
-      Forbidden
-    } else {
-      f(request, form)
-    }
+    (for{
+      email <- request.user.email
+      u <- UserService.findByEmailAndProvider(email, AuthenticationMethod.UserPassword.method)
+    } yield{
+      f(SecuredRequest(u, request.request),form)
+    }).getOrElse(Forbidden)
   }
 
   def page = SecuredAction { implicit request =>


### PR DESCRIPTION
As long as he also has a usernamepassword on his account, whether he is logged in with a social account or with the username password. 

This is a possible implementation for the feature and needs review.
