### PR TITLE
Use named loggers for all providers logging

### DIFF
--- a/module-code/app/securesocial/core/OAuth1Provider.scala
+++ b/module-code/app/securesocial/core/OAuth1Provider.scala
@@ -100,7 +100,7 @@ object ServiceInfoHelper {
  */
 abstract class OAuth1Provider(routesService: RoutesService,
                               cacheService: CacheService, val client: OAuth1Client) extends IdentityProvider  {
-  private val logger = play.api.Logger("securesocial.core.OAuth1Provider")
+  protected val logger = play.api.Logger(this.getClass.getName)
 
   def authMethod = AuthenticationMethod.OAuth1
 

--- a/module-code/app/securesocial/core/OAuth2Provider.scala
+++ b/module-code/app/securesocial/core/OAuth2Provider.scala
@@ -34,7 +34,7 @@ abstract class OAuth2Provider(settings: OAuth2Settings,
                               routesService: RoutesService,
                               httpService: HttpService,
                               cacheService: CacheService) extends IdentityProvider with ApiSupport {
-  private val logger = play.api.Logger("securesocial.core.OAuth2Provider")
+  protected val logger = play.api.Logger(this.getClass.getName)
 
   def authMethod = AuthenticationMethod.OAuth2
 

--- a/module-code/app/securesocial/core/providers/FacebookProvider.scala
+++ b/module-code/app/securesocial/core/providers/FacebookProvider.scala
@@ -55,7 +55,7 @@ class FacebookProvider(routesService: RoutesService,
         case Array(AccessToken, token, Expires, expiresIn) => OAuth2Info(token, None, Some(expiresIn.toInt))
         case Array(AccessToken, token) => OAuth2Info(token)
         case _ =>
-          Logger.error("[securesocial] invalid response format for accessToken")
+          logger.error("[securesocial] invalid response format for accessToken")
           throw new AuthenticationException()
     }
   }
@@ -70,7 +70,7 @@ class FacebookProvider(routesService: RoutesService,
           case Some(error) =>
             val message = (error \ Message).as[String]
             val errorType = (error \ Type).as[String]
-            Logger.error(
+            logger.error(
               "[securesocial] error retrieving profile information from Facebook. Error type: %s, message: %s".
                 format(errorType, message)
             )
@@ -88,7 +88,7 @@ class FacebookProvider(routesService: RoutesService,
     } recover {
       case e: AuthenticationException => throw e
       case e =>
-        Logger.error("[securesocial] error retrieving profile information from Facebook",  e)
+        logger.error("[securesocial] error retrieving profile information from Facebook",  e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/FoursquareProvider.scala
+++ b/module-code/app/securesocial/core/providers/FoursquareProvider.scala
@@ -58,7 +58,7 @@ class FoursquareProvider(routesService: RoutesService,
 
         (me \ "response" \ "user").asOpt[String] match {
           case Some(msg) =>
-            Logger.error("[securesocial] error retrieving profile information from Foursquare. Message = %s".format(msg))
+            logger.error("[securesocial] error retrieving profile information from Foursquare. Message = %s".format(msg))
             throw new AuthenticationException()
           case _ =>
             val userId = (me \ Response \ User \ Id).as[String]
@@ -73,7 +73,7 @@ class FoursquareProvider(routesService: RoutesService,
     } recover {
       case e: AuthenticationException => throw e
       case e  =>
-        Logger.error( "[securesocial] error retrieving profile information from Foursquare", e)
+        logger.error( "[securesocial] error retrieving profile information from Foursquare", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/GitHubProvider.scala
+++ b/module-code/app/securesocial/core/providers/GitHubProvider.scala
@@ -50,7 +50,7 @@ class GitHubProvider(routesService: RoutesService,
         .map( r => (r(0), r(1)))(collection.breakOut)
     val accessToken = values.get(OAuth2Constants.AccessToken)
     if ( accessToken.isEmpty ) {
-      Logger.error(s"[securesocial] did not get accessToken from $id")
+      logger.error(s"[securesocial] did not get accessToken from $id")
       throw new AuthenticationException()
     }
     OAuth2Info(
@@ -68,7 +68,7 @@ class GitHubProvider(routesService: RoutesService,
         val me = response.json
         (me \ Message).asOpt[String] match {
           case Some(msg) =>
-            Logger.error(s"[securesocial] error retrieving profile information from GitHub. Message = $msg")
+            logger.error(s"[securesocial] error retrieving profile information from GitHub. Message = $msg")
             throw new AuthenticationException()
           case _ =>
             val userId = (me \ Id).as[Int]
@@ -80,7 +80,7 @@ class GitHubProvider(routesService: RoutesService,
     } recover {
       case e: AuthenticationException => throw e
       case e  =>
-        Logger.error( "[securesocial] error retrieving profile information from github", e)
+        logger.error( "[securesocial] error retrieving profile information from github", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/GoogleProvider.scala
+++ b/module-code/app/securesocial/core/providers/GoogleProvider.scala
@@ -56,7 +56,7 @@ class GoogleProvider(routesService: RoutesService,
           case Some(error) =>
             val message = (error \ Message).as[String]
             val errorType = (error \ Type).as[String]
-            Logger.error("[securesocial] error retrieving profile information from Google. Error type = %s, message = %s"
+            logger.error("[securesocial] error retrieving profile information from Google. Error type = %s, message = %s"
               .format(errorType, message))
             throw new AuthenticationException()
           case _ =>
@@ -71,7 +71,7 @@ class GoogleProvider(routesService: RoutesService,
     } recover {
       case e: AuthenticationException => throw e
       case e =>
-        Logger.error( "[securesocial] error retrieving profile information from Google", e)
+        logger.error( "[securesocial] error retrieving profile information from Google", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/InstagramProvider.scala
+++ b/module-code/app/securesocial/core/providers/InstagramProvider.scala
@@ -52,7 +52,7 @@ class InstagramProvider(routesService: RoutesService,
 
         (me \ "response" \ "user").asOpt[String] match {
           case Some(msg) => {
-            Logger.error(s"[securesocial] error retrieving profile information from Instagram. Message = $msg")
+            logger.error(s"[securesocial] error retrieving profile information from Instagram. Message = $msg")
             throw new AuthenticationException()
           }
           case _ =>
@@ -64,7 +64,7 @@ class InstagramProvider(routesService: RoutesService,
     } recover {
       case e: AuthenticationException => throw e
       case e: Exception =>
-        Logger.error( "[securesocial] error retrieving profile information from Instagram", e)
+        logger.error( "[securesocial] error retrieving profile information from Instagram", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
+++ b/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
@@ -44,7 +44,7 @@ class LinkedInOAuth2Provider(routesService: RoutesService,
             val message = (me \ Message).asOpt[String]
             val requestId = (me \ RequestId).asOpt[String]
             val timestamp = (me \ Timestamp).asOpt[String]
-            Logger.error(
+            logger.error(
               s"Error retrieving information from LinkedIn. Error code: $error, requestId: $requestId, message: $message, timestamp: $timestamp"
             )
             throw new AuthenticationException()
@@ -62,7 +62,7 @@ class LinkedInOAuth2Provider(routesService: RoutesService,
     } recover {
       case e: AuthenticationException => throw e
       case e  =>
-        Logger.error("[securesocial] error retrieving profile information from LinkedIn", e)
+        logger.error("[securesocial] error retrieving profile information from LinkedIn", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/LinkedInProvider.scala
+++ b/module-code/app/securesocial/core/providers/LinkedInProvider.scala
@@ -53,7 +53,7 @@ class LinkedInProvider(
             val message = (me \ Message).asOpt[String]
             val requestId = (me \ RequestId).asOpt[String]
             val timestamp = (me \ Timestamp).asOpt[String]
-            Logger.error(
+            logger.error(
               s"Error retrieving information from LinkedIn. Error code: $error, requestId: $requestId, message: $message, timestamp: $timestamp"
             )
             throw new AuthenticationException()
@@ -70,7 +70,7 @@ class LinkedInProvider(
     } recover {
       case e: AuthenticationException => throw e
       case e =>
-        Logger.error("[securesocial] error retrieving profile information from LinkedIn", e)
+        logger.error("[securesocial] error retrieving profile information from LinkedIn", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/TwitterProvider.scala
+++ b/module-code/app/securesocial/core/providers/TwitterProvider.scala
@@ -53,7 +53,7 @@ class TwitterProvider(
       BasicProfile(id, userId, None, None, name, None, avatar, authMethod, Some(info))
     } recover {
       case e =>
-        Logger.error("[securesocial] error retrieving profile information from Twitter", e)
+        logger.error("[securesocial] error retrieving profile information from Twitter", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/VkProvider.scala
+++ b/module-code/app/securesocial/core/providers/VkProvider.scala
@@ -38,7 +38,7 @@ class VkProvider(routesService: RoutesService,
           case Some(error) =>
             val message = (error \ ErrorMessage).as[String]
             val errorCode = (error \ ErrorCode).as[Int]
-            Logger.error(
+            logger.error(
               s"[securesocial] error retrieving profile information from Vk. Error code = $errorCode, message = $message"
             )
             throw new AuthenticationException()
@@ -53,7 +53,7 @@ class VkProvider(routesService: RoutesService,
     } recover {
       case e: AuthenticationException => throw e
       case e: Exception =>
-        Logger.error("[securesocial] error retrieving profile information from VK", e)
+        logger.error("[securesocial] error retrieving profile information from VK", e)
         throw new AuthenticationException()
     }
   }

--- a/module-code/app/securesocial/core/providers/XingProvider.scala
+++ b/module-code/app/securesocial/core/providers/XingProvider.scala
@@ -60,7 +60,7 @@ class XingProvider(
       BasicProfile(id, userId, displayName, firstName, lastName, email, profileImage, authMethod, Some(info))
     } recover {
       case e =>
-        Logger.error("[securesocial] error retrieving profile information from Xing", e)
+        logger.error("[securesocial] error retrieving profile information from Xing", e)
         throw new AuthenticationException()
     }
   }


### PR DESCRIPTION
I changed both root social provider to make their logger protected and className based, this way each provider has access to a custom logger (enabling activation/deactivation of logging on a single provider at a time)

This made it possible to remove all direct calls on the Logger object (and thus all calls logged with the `application` logger)
