### PR TITLE
Async ViewsPlugin

### DIFF
--- a/module-code/app/securesocial/controllers/PasswordChange.scala
+++ b/module-code/app/securesocial/controllers/PasswordChange.scala
@@ -25,6 +25,7 @@ import securesocial.core.providers.utils.PasswordValidator
 import play.api.i18n.Messages
 import scala.Some
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits._
 
 /**
  * A default PasswordChange controller that uses the BasicProfile as the user type
@@ -110,8 +111,8 @@ trait BasePasswordChange[U] extends SecureSocial[U] {
    */
   def page = SecuredAction.async { implicit request =>
     execute { form: Form[ChangeInfo] =>
-      Future.successful {
-        Ok(env.viewTemplates.getPasswordChangePage(form))
+      env.viewTemplates.getPasswordChangePage(form) map { view =>
+        Ok(view)
       }
     }
   }
@@ -124,7 +125,9 @@ trait BasePasswordChange[U] extends SecureSocial[U] {
   def handlePasswordChange = SecuredAction.async { implicit request =>
     execute { form: Form[ChangeInfo] =>
       form.bindFromRequest()(request).fold (
-        errors => Future.successful(BadRequest(env.viewTemplates.getPasswordChangePage(errors))),
+        errors => env.viewTemplates.getPasswordChangePage(errors) map { view =>
+          BadRequest(view)
+        },
         info =>  {
           val newPasswordInfo = env.currentHasher.hash(info.newPassword)
           import ExecutionContext.Implicits.global

--- a/module-code/app/securesocial/controllers/ViewsPlugin.scala
+++ b/module-code/app/securesocial/controllers/ViewsPlugin.scala
@@ -16,7 +16,7 @@
  */
 package securesocial.controllers
 
-import play.api.mvc.{Controller, RequestHeader}
+import play.api.mvc.{Controller, Request}
 import play.api.templates.{Html, Txt}
 import securesocial.core.{BasicProfile, RuntimeEnvironment}
 import play.api.data.Form
@@ -35,37 +35,37 @@ trait ViewTemplates extends Controller {
   /**
    * Returns the html for the login page
    */
-  def getLoginPage(form: Form[(String, String)], msg: Option[String] = None)(implicit request: RequestHeader, lang: Lang): Html
+  def getLoginPage(form: Form[(String, String)], msg: Option[String] = None)(implicit request: Request[_], lang: Lang): Html
 
   /**
    * Returns the html for the signup page
    */
-  def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: RequestHeader, lang: Lang): Html
+  def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[_], lang: Lang): Html
 
   /**
    * Returns the html for the start signup page
    */
-  def getStartSignUpPage(form: Form[String])(implicit request: RequestHeader, lang: Lang): Html
+  def getStartSignUpPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html
 
   /**
    * Returns the html for the reset password page
    */
-  def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: RequestHeader, lang: Lang): Html
+  def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[_], lang: Lang): Html
 
   /**
    * Returns the html for the start reset page
    */
-  def getStartResetPasswordPage(form: Form[String])(implicit request: RequestHeader, lang: Lang): Html
+  def getStartResetPasswordPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html
 
   /**
    * Returns the html for the change password page
    */
-  def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: RequestHeader, lang: Lang): Html
+  def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: Request[_], lang: Lang): Html
 
   /**
    * Returns the html for the not authorized page
    */
-  def getNotAuthorizedPage(implicit request: RequestHeader, lang: Lang): Html
+  def getNotAuthorizedPage(implicit request: Request[_], lang: Lang): Html
 }
 
 /**
@@ -79,7 +79,7 @@ trait MailTemplates extends Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getSignUpEmail(token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getSignUpEmail(token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent when the user is already registered
@@ -88,7 +88,7 @@ trait MailTemplates extends Controller {
    * @param request the current request
    * @return a tuple with the text and/or html body for the email
    */
-  def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the welcome email sent when the user finished the sign up process
@@ -97,7 +97,7 @@ trait MailTemplates extends Controller {
    * @param request the current request
    * @return a String with the text and/or html body for the email
    */
-  def getWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent when a user tries to reset the password but there is no account for
@@ -106,7 +106,7 @@ trait MailTemplates extends Controller {
    * @param request the current request
    * @return a String with the text and/or html body for the email
    */
-  def getUnknownEmailNotice()(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getUnknownEmailNotice()(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent to the user to reset the password
@@ -116,7 +116,7 @@ trait MailTemplates extends Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent as a confirmation of a password change
@@ -125,7 +125,7 @@ trait MailTemplates extends Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
 
 }
 
@@ -137,31 +137,31 @@ object ViewTemplates {
     implicit val implicitEnv = env
 
     override def getLoginPage(form: Form[(String, String)],
-                              msg: Option[String] = None)(implicit request: RequestHeader, lang: Lang): Html = {
+                              msg: Option[String] = None)(implicit request: Request[_], lang: Lang): Html = {
       securesocial.views.html.login(form, msg)
     }
 
-    override def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: RequestHeader, lang: Lang): Html = {
+    override def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[_], lang: Lang): Html = {
       securesocial.views.html.Registration.signUp(form, token)
     }
 
-    override def getStartSignUpPage(form: Form[String])(implicit request: RequestHeader, lang: Lang): Html = {
+    override def getStartSignUpPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html = {
       securesocial.views.html.Registration.startSignUp(form)
     }
 
-    override def getStartResetPasswordPage(form: Form[String])(implicit request: RequestHeader, lang: Lang): Html = {
+    override def getStartResetPasswordPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html = {
       securesocial.views.html.Registration.startResetPassword(form)
     }
 
-    override def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: RequestHeader, lang: Lang): Html = {
+    override def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[_], lang: Lang): Html = {
       securesocial.views.html.Registration.resetPasswordPage(form, token)
     }
 
-    override def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: RequestHeader, lang: Lang): Html = {
+    override def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: Request[_], lang: Lang): Html = {
       securesocial.views.html.passwordChange(form)
     }
 
-    def getNotAuthorizedPage(implicit request: RequestHeader, lang: Lang): Html = {
+    def getNotAuthorizedPage(implicit request: Request[_], lang: Lang): Html = {
       securesocial.views.html.notAuthorized()
     }
   }
@@ -173,27 +173,27 @@ object MailTemplates {
    */
   class Default(env: RuntimeEnvironment[_]) extends MailTemplates {
     implicit val implicitEnv = env
-    def getSignUpEmail(token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getSignUpEmail(token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.signUpEmail(token)))
     }
 
-    def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.alreadyRegisteredEmail(user)))
     }
 
-    def getWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.welcomeEmail(user)))
     }
 
-    def getUnknownEmailNotice()(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getUnknownEmailNotice()(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.unknownEmailNotice()))
     }
 
-    def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.passwordResetEmail(user, token)))
     }
 
-    def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.passwordChangedNotice(user)))
     }
   }

--- a/module-code/app/securesocial/controllers/ViewsPlugin.scala
+++ b/module-code/app/securesocial/controllers/ViewsPlugin.scala
@@ -21,6 +21,7 @@ import play.api.templates.{Html, Txt}
 import securesocial.core.{BasicProfile, RuntimeEnvironment}
 import play.api.data.Form
 import play.api.i18n.Lang
+import scala.concurrent.Future
 
 /**
  * A trait that provides the pages for SecureSocial
@@ -35,37 +36,37 @@ trait ViewTemplates extends Controller {
   /**
    * Returns the html for the login page
    */
-  def getLoginPage(form: Form[(String, String)], msg: Option[String] = None)(implicit request: Request[_], lang: Lang): Html
+  def getLoginPage(form: Form[(String, String)], msg: Option[String] = None)(implicit request: Request[_], lang: Lang): Future[Html]
 
   /**
    * Returns the html for the signup page
    */
-  def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[_], lang: Lang): Html
+  def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[_], lang: Lang): Future[Html]
 
   /**
    * Returns the html for the start signup page
    */
-  def getStartSignUpPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html
+  def getStartSignUpPage(form: Form[String])(implicit request: Request[_], lang: Lang): Future[Html]
 
   /**
    * Returns the html for the reset password page
    */
-  def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[_], lang: Lang): Html
+  def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[_], lang: Lang): Future[Html]
 
   /**
    * Returns the html for the start reset page
    */
-  def getStartResetPasswordPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html
+  def getStartResetPasswordPage(form: Form[String])(implicit request: Request[_], lang: Lang): Future[Html]
 
   /**
    * Returns the html for the change password page
    */
-  def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: Request[_], lang: Lang): Html
+  def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: Request[_], lang: Lang): Future[Html]
 
   /**
    * Returns the html for the not authorized page
    */
-  def getNotAuthorizedPage(implicit request: Request[_], lang: Lang): Html
+  def getNotAuthorizedPage(implicit request: Request[_], lang: Lang): Future[Html]
 }
 
 /**
@@ -79,7 +80,7 @@ trait MailTemplates extends Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getSignUpEmail(token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
+  def getSignUpEmail(token: String)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])]
 
   /**
    * Returns the email sent when the user is already registered
@@ -88,7 +89,7 @@ trait MailTemplates extends Controller {
    * @param request the current request
    * @return a tuple with the text and/or html body for the email
    */
-  def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
+  def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])]
 
   /**
    * Returns the welcome email sent when the user finished the sign up process
@@ -97,7 +98,7 @@ trait MailTemplates extends Controller {
    * @param request the current request
    * @return a String with the text and/or html body for the email
    */
-  def getWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
+  def getWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])]
 
   /**
    * Returns the email sent when a user tries to reset the password but there is no account for
@@ -106,7 +107,7 @@ trait MailTemplates extends Controller {
    * @param request the current request
    * @return a String with the text and/or html body for the email
    */
-  def getUnknownEmailNotice()(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
+  def getUnknownEmailNotice()(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])]
 
   /**
    * Returns the email sent to the user to reset the password
@@ -116,7 +117,7 @@ trait MailTemplates extends Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
+  def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])]
 
   /**
    * Returns the email sent as a confirmation of a password change
@@ -125,7 +126,7 @@ trait MailTemplates extends Controller {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html])
+  def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])]
 
 }
 
@@ -137,31 +138,31 @@ object ViewTemplates {
     implicit val implicitEnv = env
 
     override def getLoginPage(form: Form[(String, String)],
-                              msg: Option[String] = None)(implicit request: Request[_], lang: Lang): Html = {
+                              msg: Option[String] = None)(implicit request: Request[_], lang: Lang): Future[Html] = Future.successful {
       securesocial.views.html.login(form, msg)
     }
 
-    override def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[_], lang: Lang): Html = {
+    override def getSignUpPage(form: Form[RegistrationInfo], token: String)(implicit request: Request[_], lang: Lang): Future[Html] = Future.successful {
       securesocial.views.html.Registration.signUp(form, token)
     }
 
-    override def getStartSignUpPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html = {
+    override def getStartSignUpPage(form: Form[String])(implicit request: Request[_], lang: Lang): Future[Html] = Future.successful {
       securesocial.views.html.Registration.startSignUp(form)
     }
 
-    override def getStartResetPasswordPage(form: Form[String])(implicit request: Request[_], lang: Lang): Html = {
+    override def getStartResetPasswordPage(form: Form[String])(implicit request: Request[_], lang: Lang): Future[Html] = Future.successful {
       securesocial.views.html.Registration.startResetPassword(form)
     }
 
-    override def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[_], lang: Lang): Html = {
+    override def getResetPasswordPage(form: Form[(String, String)], token: String)(implicit request: Request[_], lang: Lang): Future[Html] = Future.successful {
       securesocial.views.html.Registration.resetPasswordPage(form, token)
     }
 
-    override def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: Request[_], lang: Lang): Html = {
+    override def getPasswordChangePage(form: Form[ChangeInfo])(implicit request: Request[_], lang: Lang): Future[Html] = Future.successful {
       securesocial.views.html.passwordChange(form)
     }
 
-    def getNotAuthorizedPage(implicit request: Request[_], lang: Lang): Html = {
+    def getNotAuthorizedPage(implicit request: Request[_], lang: Lang): Future[Html] = Future.successful {
       securesocial.views.html.notAuthorized()
     }
   }
@@ -173,27 +174,27 @@ object MailTemplates {
    */
   class Default(env: RuntimeEnvironment[_]) extends MailTemplates {
     implicit val implicitEnv = env
-    def getSignUpEmail(token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
+    def getSignUpEmail(token: String)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])] = Future.successful {
       (None, Some(securesocial.views.html.mails.signUpEmail(token)))
     }
 
-    def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
+    def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])] = Future.successful {
       (None, Some(securesocial.views.html.mails.alreadyRegisteredEmail(user)))
     }
 
-    def getWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
+    def getWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])] = Future.successful {
       (None, Some(securesocial.views.html.mails.welcomeEmail(user)))
     }
 
-    def getUnknownEmailNotice()(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
+    def getUnknownEmailNotice()(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])] = Future.successful {
       (None, Some(securesocial.views.html.mails.unknownEmailNotice()))
     }
 
-    def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
+    def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])] = Future.successful {
       (None, Some(securesocial.views.html.mails.passwordResetEmail(user, token)))
     }
 
-    def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): (Option[Txt], Option[Html]) = {
+    def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang): Future[(Option[Txt], Option[Html])] = Future.successful {
       (None, Some(securesocial.views.html.mails.passwordChangedNotice(user)))
     }
   }

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -191,7 +191,7 @@ object SecureSocial {
    * @param result the result that maybe enhanced with an updated session
    * @return the result that's returned to the client
    */
-  def withRefererAsOriginalUrl[A](result: Result)(implicit request: Request[A]): Result = {
+  def withRefererAsOriginalUrl[A](result: SimpleResult)(implicit request: Request[A]): SimpleResult = {
     request.session.get(OriginalUrlKey) match {
       // If there's already an original url recorded we keep it: e.g. if s.o. goes to
       // login, switches to signup and goes back to login we want to keep the first referer

--- a/module-code/app/securesocial/core/providers/utils/Mailer.scala
+++ b/module-code/app/securesocial/core/providers/utils/Mailer.scala
@@ -21,7 +21,7 @@ import play.api.Play
 import securesocial.controllers.MailTemplates
 import Play.current
 import play.api.libs.concurrent.Akka
-import play.api.mvc.RequestHeader
+import play.api.mvc.Request
 import play.api.i18n.{Lang, Messages}
 import play.api.templates.{Html, Txt}
 
@@ -29,12 +29,12 @@ import play.api.templates.{Html, Txt}
  * A helper trait to send email notifications
  */
 trait Mailer {
-  def sendAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang)
-  def sendSignUpEmail(to: String, token: String)(implicit request: RequestHeader, lang: Lang)
-  def sendWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang)
-  def sendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang)
-  def sendUnkownEmailNotice(email: String)(implicit request: RequestHeader, lang: Lang)
-  def sendPasswordChangedNotice(user: BasicProfile)(implicit request: RequestHeader, lang: Lang)
+  def sendAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang)
+  def sendSignUpEmail(to: String, token: String)(implicit request: Request[_], lang: Lang)
+  def sendWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang)
+  def sendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang)
+  def sendUnkownEmailNotice(email: String)(implicit request: Request[_], lang: Lang)
+  def sendPasswordChangedNotice(user: BasicProfile)(implicit request: Request[_], lang: Lang)
   def sendEmail(subject: String, recipient: String, body: (Option[Txt], Option[Html]))
 }
 
@@ -56,34 +56,34 @@ object Mailer {
     val PasswordResetOkSubject = "mails.passwordResetOk.subject"
 
 
-    override def sendAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang) {
+    override def sendAlreadyRegisteredEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang) {
       val txtAndHtml = mailTemplates.getAlreadyRegisteredEmail(user)
       sendEmail(Messages(AlreadyRegisteredSubject), user.email.get, txtAndHtml)
 
     }
 
-    override def sendSignUpEmail(to: String, token: String)(implicit request: RequestHeader, lang: Lang) {
+    override def sendSignUpEmail(to: String, token: String)(implicit request: Request[_], lang: Lang) {
       val txtAndHtml = mailTemplates.getSignUpEmail(token)
       sendEmail(Messages(SignUpEmailSubject), to, txtAndHtml)
     }
 
-    override def sendWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang) {
+    override def sendWelcomeEmail(user: BasicProfile)(implicit request: Request[_], lang: Lang) {
       val txtAndHtml = mailTemplates.getWelcomeEmail(user)
       sendEmail(Messages(WelcomeEmailSubject), user.email.get, txtAndHtml)
 
     }
 
-    override def sendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang) {
+    override def sendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: Request[_], lang: Lang) {
       val txtAndHtml = mailTemplates.getSendPasswordResetEmail(user, token)
       sendEmail(Messages(PasswordResetSubject), user.email.get, txtAndHtml)
     }
 
-    override def sendUnkownEmailNotice(email: String)(implicit request: RequestHeader, lang: Lang) {
+    override def sendUnkownEmailNotice(email: String)(implicit request: Request[_], lang: Lang) {
       val txtAndHtml = mailTemplates.getUnknownEmailNotice()
       sendEmail(Messages(UnknownEmailNoticeSubject), email, txtAndHtml)
     }
 
-    override def sendPasswordChangedNotice(user: BasicProfile)(implicit request: RequestHeader, lang: Lang) {
+    override def sendPasswordChangedNotice(user: BasicProfile)(implicit request: Request[_], lang: Lang) {
       val txtAndHtml = mailTemplates.getPasswordChangedNoticeEmail(user)
       sendEmail(Messages(PasswordResetOkSubject), user.email.get, txtAndHtml)
     }

--- a/module-code/test/scenarios/GoogleLoginSpec.scala
+++ b/module-code/test/scenarios/GoogleLoginSpec.scala
@@ -3,7 +3,6 @@ package scenarios
 import org.specs2.mutable.Specification
 import org.specs2.mock.Mockito
 import play.api.test.{FakeApplication, PlaySpecification, WithApplication}
-
 import scenarios.helpers.{TestGlobal, DemoUser, TestUserService}
 import securesocial.core.providers.GoogleProvider
 import securesocial.core.{IdentityProvider, EventListener, RuntimeEnvironment}
@@ -13,9 +12,9 @@ import org.specs2.matcher.Matcher
 import play.api.libs.ws.Response
 import scala.concurrent.Future
 import play.api.libs.json.Json
-
 import scenarios.helpers.Api._
 import java.io.File
+import scala.collection.immutable.ListMap
 
 class GoogleLoginSpec extends PlaySpecification with Mockito {
 
@@ -72,7 +71,7 @@ class GoogleLoginSpec extends PlaySpecification with Mockito {
     override lazy val userService: UserService[DemoUser] = _userService
     override lazy val eventListeners: List[EventListener[DemoUser]] = _eventListeners
     override lazy val httpService : HttpService = _httpService
-    override lazy val providers: Map[String, IdentityProvider] = Map(include(new GoogleProvider(routes, cacheService, oauth2ClientFor(GoogleProvider.Google))))
+    override lazy val providers: ListMap[String, IdentityProvider] = ListMap(include(new GoogleProvider(routes, cacheService, oauth2ClientFor(GoogleProvider.Google))))
   }
   val googleConfig = Map(
      "smtp.mock"->true


### PR DESCRIPTION
ViewTemplates and EmailTemplates are made async in this patch. Now it's possible to do asynchronous actions before rendering views or email templates. It's useful when views have layouts with dynamic contents like menu, ads, banner, etc.

This was my problem which is solved by this patch: https://groups.google.com/d/msg/securesocial/fHb3vsl-qBw/rexdWE9FF_4J
