### PR TITLE
separate creation and storage of mail tokens

### DIFF
--- a/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
+++ b/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
@@ -54,17 +54,15 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
    * @return a MailToken instance
    */
   def createToken(email: String, isSignUp: Boolean): Future[MailToken] = {
-    val uuid = UUID.randomUUID().toString
     val now = DateTime.now
 
-    val token = MailToken(
-      uuid, email.toLowerCase,
-      now,
-      now.plusMinutes(TokenDuration),
-      isSignUp = isSignUp
-    )
-    import ExecutionContext.Implicits.global
-    env.userService.saveToken(token).map(_ => token)
+    Future.successful(MailToken(
+      UUID.randomUUID().toString
+    , email.toLowerCase
+    , now
+    , now.plusMinutes(TokenDuration)
+    , isSignUp = isSignUp
+    ))
   }
 
   /**

--- a/module-code/app/securesocial/controllers/PasswordReset.scala
+++ b/module-code/app/securesocial/controllers/PasswordReset.scala
@@ -73,9 +73,9 @@ trait BasePasswordReset[U] extends MailTokenBasedOperations[U] {
           maybeUser =>
             maybeUser match {
               case Some(user) =>
-                createToken(email, isSignUp = false).map {
-                  token =>
-                    env.mailer.sendPasswordResetEmail(user, token.uuid)
+                createToken(email, isSignUp = false).map { token =>
+                  env.mailer.sendPasswordResetEmail(user, token.uuid)
+                  env.userService.saveToken(token)
                 }
               case None =>
                 env.mailer.sendUnkownEmailNotice(email)

--- a/module-code/app/securesocial/controllers/Registration.scala
+++ b/module-code/app/securesocial/controllers/Registration.scala
@@ -125,8 +125,9 @@ trait BaseRegistration[U] extends MailTokenBasedOperations[U] {
                   env.mailer.sendAlreadyRegisteredEmail(user)
                 case None =>
                   import scala.concurrent.ExecutionContext.Implicits.global
-                  createToken(email, isSignUp = true).map { token =>
-                      env.mailer.sendSignUpEmail(email, token.uuid)
+                  createToken(email, isSignUp = true).flatMap { token =>
+                    env.mailer.sendSignUpEmail(email, token.uuid)
+                    env.userService.saveToken(token)
                   }
               }
               handleStartResult().flashing(Success -> Messages(ThankYouCheckEmail), Email -> email)


### PR DESCRIPTION
`MailTokenBasedOperations#createToken` only creates a mailer token.

In turn, `handleStartSignUp` and `handleStartResetPassword` are
responsible for storage of the respective mail token.
