### PR TITLE
Use large version of Facebook profile picture

### DIFF
--- a/module-code/app/securesocial/core/providers/FacebookProvider.scala
+++ b/module-code/app/securesocial/core/providers/FacebookProvider.scala
@@ -30,7 +30,7 @@ class FacebookProvider(routesService: RoutesService,
   cacheService: CacheService,
   client: OAuth2Client)
     extends OAuth2Provider(routesService, client, cacheService) {
-  val MeApi = "https://graph.facebook.com/me?fields=name,first_name,last_name,picture,email&return_ssl_resources=1&access_token="
+  val MeApi = "https://graph.facebook.com/me?fields=name,first_name,last_name,picture.type(large),email&return_ssl_resources=1&access_token="
   val Error = "error"
   val Message = "message"
   val Type = "type"


### PR DESCRIPTION
Previous one is too small and not usable. Especially on mobile device, it becomes blur for most of profile pictures.
