### PR TITLE
Add support for path to custom bootstrap css file

### DIFF
--- a/module-code/app/securesocial/core/services/RoutesService.scala
+++ b/module-code/app/securesocial/core/services/RoutesService.scala
@@ -29,6 +29,7 @@ trait RoutesService {
   def authenticationUrl(provider: String, redirectTo: Option[String] = None)(implicit req: RequestHeader): String
   def faviconPath: Call
   def jqueryPath: Call
+  def bootstrapCssPath: Call
   def customCssPath: Option[Call]
 }
 
@@ -43,9 +44,11 @@ object RoutesService {
 
     val FaviconKey = "securesocial.faviconPath"
     val JQueryKey = "securesocial.jqueryPath"
+    val BootstrapCssKey = "securesocial.bootstrapCssPath"
     val CustomCssKey = "securesocial.customCssPath"
     val DefaultFaviconPath = "images/favicon.png"
     val DefaultJqueryPath = "javascripts/jquery-1.7.1.min.js"
+    val DefaultBootstrapCssPath = "bootstrap/css/bootstrap.min.css"
 
     protected def absoluteUrl(call: Call)(implicit req: RequestHeader): String = {
       call.absoluteURL(IdentityProvider.sslEnabled)
@@ -85,6 +88,11 @@ object RoutesService {
      */
     override val jqueryPath = valueFor(JQueryKey, DefaultJqueryPath)
 
+    /**
+     * Loads the Bootstrap CSS file to use from configuration, using a default one if not provided
+     * @return the path to Bootstrap CSS file to use
+     */
+    override val bootstrapCssPath = valueFor(BootstrapCssKey, DefaultBootstrapCssPath)
     /**
      * Loads the Custom Css file to use from configuration. If there is none define, none will be used
      * @return Option containing a custom css file or None

--- a/module-code/app/securesocial/views/main.scala.html
+++ b/module-code/app/securesocial/views/main.scala.html
@@ -5,7 +5,7 @@
 <html>
     <head>
         <title>@title</title>
-        <link rel="stylesheet" media="screen" href="@securesocial.controllers.routes.Assets.at("bootstrap/css/bootstrap.min.css")">
+        <link rel="stylesheet" media="screen" href="@env.routes.bootstrapCssPath">
         <link rel="shortcut icon" type="image/png" href="@env.routes.faviconPath">
         @env.routes.customCssPath.map { customPath =>
             <link rel="stylesheet" media="screen" href="@customPath">


### PR DESCRIPTION
Fixes issue #467 and brings plugin up-to-date with documentation regarding allowing custom bootstrap CSS.

Follows the same pattern as JQuery/Favicon paths.

Tested locally both with custom bootstrap path and no path specified.