### PR TITLE
Make reset password URL configurable.

### DIFF
--- a/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
+++ b/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
@@ -78,7 +78,7 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
       env.userService.findToken(token).flatMap {
         case Some(t) if !t.isExpired && t.isSignUp == isSignUp => f(t)
         case _ =>
-          val to = if (isSignUp) env.routes.signUpUrl else env.routes.resetPasswordUrl
+          val to = if (isSignUp) env.routes.signUpUrl else env.routes.startResetPasswordUrl
           Future.successful(Redirect(to).flashing(Error -> Messages(BaseRegistration.InvalidLink)))
       }
     }

--- a/module-code/app/securesocial/core/services/RoutesService.scala
+++ b/module-code/app/securesocial/core/services/RoutesService.scala
@@ -25,7 +25,8 @@ import securesocial.core.IdentityProvider
 trait RoutesService {
   def loginPageUrl(implicit req: RequestHeader): String
   def signUpUrl(implicit req: RequestHeader): String
-  def resetPasswordUrl(implicit req: RequestHeader): String
+  def startResetPasswordUrl(implicit req: RequestHeader): String
+  def resetPasswordUrl(mailToken: String)(implicit req: RequestHeader): String
   def authenticationUrl(provider: String, redirectTo: Option[String] = None)(implicit req: RequestHeader): String
   def faviconPath: Call
   def jqueryPath: Call
@@ -59,8 +60,12 @@ object RoutesService {
       absoluteUrl(securesocial.controllers.routes.Registration.startSignUp())
     }
 
-    override def resetPasswordUrl(implicit request: RequestHeader): String = {
+    override def startResetPasswordUrl(implicit request: RequestHeader): String = {
       absoluteUrl(securesocial.controllers.routes.PasswordReset.startResetPassword())
+    }
+
+    override def resetPasswordUrl(mailToken: String)(implicit req: RequestHeader): String = {
+      absoluteUrl(securesocial.controllers.routes.PasswordReset.resetPassword(mailToken))
     }
 
     override def authenticationUrl(provider: String, redirectTo: Option[String] = None)(implicit req: RequestHeader): String = {

--- a/module-code/app/securesocial/views/mails/alreadyRegisteredEmail.scala.html
+++ b/module-code/app/securesocial/views/mails/alreadyRegisteredEmail.scala.html
@@ -5,6 +5,6 @@
         <p>Hello @user.firstName,</p>
 
         <p>You tried to sign up but you already have an account with us.  If you don't remember your password please go
-            <a href="@env.routes.resetPasswordUrl">here</a> to reset it.</p>
+            <a href="@env.routes.startResetPasswordUrl">here</a> to reset it.</p>
     </body>
 </html>

--- a/module-code/app/securesocial/views/mails/passwordResetEmail.scala.html
+++ b/module-code/app/securesocial/views/mails/passwordResetEmail.scala.html
@@ -5,7 +5,7 @@
 <p>Hello @user.firstName,</p>
 
 <p>Please follow this
-    <a href="@securesocial.controllers.routes.PasswordReset.resetPassword(mailToken).absoluteURL(IdentityProvider.sslEnabled)">
+    <a href="@env.routes.resetPasswordUrl(mailToken)">
     link</a> to reset your password.
 </p>
 </body>

--- a/module-code/app/securesocial/views/provider.scala.html
+++ b/module-code/app/securesocial/views/provider.scala.html
@@ -44,7 +44,7 @@
                             <button type="submit" class="btn btn-primary">@Messages("securesocial.login.title")</button>
                         </div>
                         <div class="clearfix">
-                            <p><a href="@env.routes.resetPasswordUrl">@Messages("securesocial.login.forgotPassword") </a></p>
+                            <p><a href="@env.routes.startResetPasswordUrl">@Messages("securesocial.login.forgotPassword") </a></p>
                         </div>
                         @if(Play.current.configuration.getBoolean("securesocial.registrationEnabled").getOrElse(true) ){
                              <div class="clearfix">


### PR DESCRIPTION
The `passwordResetEmail` has the link hardcoded to `securesocial.controllers.routes.PasswordReset.resetPassword`. This change makes this configurable.