### PR TITLE
Fix hardcoded execution context

### DIFF
--- a/module-code/app/securesocial/controllers/LoginApi.scala
+++ b/module-code/app/securesocial/controllers/LoginApi.scala
@@ -49,7 +49,6 @@ trait BaseLoginApi[U] extends SecureSocial[U] {
   val logger = play.api.Logger("securesocial.controllers.BaseLoginApi")
 
   def authenticate(providerId: String, builderId: String) = Action.async { implicit request =>
-    import ExecutionContext.Implicits.global
     val result = for (
       builder <- env.authenticatorService.find(builderId);
       provider <- env.providers.get(providerId) if provider.isInstanceOf[ApiSupport]
@@ -85,7 +84,7 @@ trait BaseLoginApi[U] extends SecureSocial[U] {
 
   def logout = Action.async { implicit request =>
     import securesocial.core.utils._
-    import ExecutionContext.Implicits.global
+
     env.authenticatorService.fromRequest(request).flatMap {
       case Some(authenticator) => Ok("").discardingAuthenticator(authenticator)
       case None => Future.successful(Ok(""))

--- a/module-code/app/securesocial/controllers/LoginPage.scala
+++ b/module-code/app/securesocial/controllers/LoginPage.scala
@@ -76,7 +76,6 @@ trait BaseLoginPage[U] extends SecureSocial[U] {
         user <- request.user
         authenticator <- request.authenticator
       } yield {
-        import ExecutionContext.Implicits.global
         redirectTo.discardingAuthenticator(authenticator).map {
           _.withSession(Events.fire(new LogoutEvent(user)).getOrElse(request.session))
         }

--- a/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
+++ b/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
@@ -74,7 +74,6 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
   protected def executeForToken(token: String, isSignUp: Boolean,
     f: MailToken => Future[Result])(implicit request: RequestHeader): Future[Result] =
     {
-      import scala.concurrent.ExecutionContext.Implicits.global
       env.userService.findToken(token).flatMap {
         case Some(t) if !t.isExpired && t.isSignUp == isSignUp => f(t)
         case _ =>

--- a/module-code/app/securesocial/controllers/PasswordChange.scala
+++ b/module-code/app/securesocial/controllers/PasswordChange.scala
@@ -66,7 +66,6 @@ trait BasePasswordChange[U] extends SecureSocial[U] {
    * @return a future boolean
    */
   def checkCurrentPassword[A](suppliedPassword: String)(implicit request: SecuredRequest[A]): Future[Boolean] = {
-    import ExecutionContext.Implicits.global
     env.userService.passwordInfoFor(request.user).map {
       case Some(info) =>
         env.passwordHashers.get(info.hasher).exists {
@@ -77,7 +76,6 @@ trait BasePasswordChange[U] extends SecureSocial[U] {
   }
 
   private def execute[A](f: Form[ChangeInfo] => Future[Result])(implicit request: SecuredRequest[A]): Future[Result] = {
-    import ExecutionContext.Implicits.global
     val form = Form[ChangeInfo](
       mapping(
         CurrentPassword ->
@@ -129,7 +127,6 @@ trait BasePasswordChange[U] extends SecureSocial[U] {
           errors => Future.successful(BadRequest(env.viewTemplates.getPasswordChangePage(errors))),
           info => {
             val newPasswordInfo = env.currentHasher.hash(info.newPassword)
-            import ExecutionContext.Implicits.global
             implicit val userLang = request2lang(request)
             env.userService.updatePasswordInfo(request.user, newPasswordInfo).map {
               case Some(u) =>

--- a/module-code/app/securesocial/controllers/PasswordReset.scala
+++ b/module-code/app/securesocial/controllers/PasswordReset.scala
@@ -70,7 +70,6 @@ trait BasePasswordReset[U] extends MailTokenBasedOperations[U] {
   def handleStartResetPassword = CSRFCheck {
     Action.async {
       implicit request =>
-        import scala.concurrent.ExecutionContext.Implicits.global
         startForm.bindFromRequest.fold(
           errors => Future.successful(BadRequest(env.viewTemplates.getStartResetPasswordPage(errors))),
           email => env.userService.findByEmailAndProvider(email, UsernamePasswordProvider.UsernamePassword).map {

--- a/module-code/app/securesocial/controllers/ProviderController.scala
+++ b/module-code/app/securesocial/controllers/ProviderController.scala
@@ -87,7 +87,6 @@ trait BaseProviderController[U] extends SecureSocial[U] {
    * @param redirectTo the url the user needs to be redirected to after being authenticated
    */
   private def handleAuth(provider: String, redirectTo: Option[String]) = UserAwareAction.async { implicit request =>
-    import scala.concurrent.ExecutionContext.Implicits.global
     val authenticationFlow = request.user.isEmpty
     val modifiedSession = overrideOriginalUrl(request.session, redirectTo)
 
@@ -112,7 +111,6 @@ trait BaseProviderController[U] extends SecureSocial[U] {
                 logger.debug(s"[securesocial] user completed authentication: provider = ${profile.providerId}, userId: ${profile.userId}, mode = $mode")
                 val evt = if (mode == SaveMode.LoggedIn) new LoginEvent(userForAction) else new SignUpEvent(userForAction)
                 val sessionAfterEvents = Events.fire(evt).getOrElse(request.session)
-                import scala.concurrent.ExecutionContext.Implicits.global
                 builder().fromUser(userForAction).flatMap { authenticator =>
                   Redirect(toUrl(sessionAfterEvents)).withSession(sessionAfterEvents -
                     SecureSocial.OriginalUrlKey -

--- a/module-code/app/securesocial/controllers/Registration.scala
+++ b/module-code/app/securesocial/controllers/Registration.scala
@@ -112,7 +112,6 @@ trait BaseRegistration[U] extends MailTokenBasedOperations[U] {
           e => {
             val email = e.toLowerCase
             // check if there is already an account for this email address
-            import scala.concurrent.ExecutionContext.Implicits.global
             env.userService.findByEmailAndProvider(email, UsernamePasswordProvider.UsernamePassword).map {
               maybeUser =>
                 maybeUser match {
@@ -120,7 +119,6 @@ trait BaseRegistration[U] extends MailTokenBasedOperations[U] {
                     // user signed up already, send an email offering to login/recover password
                     env.mailer.sendAlreadyRegisteredEmail(user)
                   case None =>
-                    import scala.concurrent.ExecutionContext.Implicits.global
                     createToken(email, isSignUp = true).flatMap { token =>
                       env.mailer.sendSignUpEmail(email, token.uuid)
                       env.userService.saveToken(token)
@@ -154,7 +152,6 @@ trait BaseRegistration[U] extends MailTokenBasedOperations[U] {
   def handleSignUp(token: String) = CSRFCheck {
     Action.async {
       implicit request =>
-        import scala.concurrent.ExecutionContext.Implicits.global
         executeForToken(token, true, {
           t =>
             form.bindFromRequest.fold(

--- a/module-code/app/securesocial/core/RuntimeEnvironment.scala
+++ b/module-code/app/securesocial/core/RuntimeEnvironment.scala
@@ -68,7 +68,7 @@ object RuntimeEnvironment {
     )
 
     override lazy val eventListeners: List[EventListener[U]] = List()
-    override implicit val executionContext: ExecutionContext =
+    override implicit def executionContext: ExecutionContext =
       ExecutionContext.Implicits.global
 
     protected def include(p: IdentityProvider) = p.id -> p

--- a/module-code/app/securesocial/core/RuntimeEnvironment.scala
+++ b/module-code/app/securesocial/core/RuntimeEnvironment.scala
@@ -9,6 +9,7 @@ import securesocial.core.services._
 import scala.concurrent.ExecutionContext
 import scala.collection.immutable.ListMap
 
+import play.api.libs.concurrent.{ Execution => PlayExecution }
 /**
  * A runtime environment where the services needed are available
  */
@@ -69,7 +70,7 @@ object RuntimeEnvironment {
 
     override lazy val eventListeners: List[EventListener[U]] = List()
     override implicit def executionContext: ExecutionContext =
-      ExecutionContext.Implicits.global
+      PlayExecution.defaultContext
 
     protected def include(p: IdentityProvider) = p.id -> p
     protected def oauth1ClientFor(provider: String) = new OAuth1Client.Default(ServiceInfoHelper.forProvider(provider), httpService)

--- a/module-code/app/securesocial/core/RuntimeEnvironment.scala
+++ b/module-code/app/securesocial/core/RuntimeEnvironment.scala
@@ -6,6 +6,7 @@ import securesocial.core.providers._
 import securesocial.core.providers.utils.{ Mailer, PasswordHasher, PasswordValidator }
 import securesocial.core.services._
 
+import scala.concurrent.ExecutionContext
 import scala.collection.immutable.ListMap
 
 /**
@@ -35,6 +36,8 @@ trait RuntimeEnvironment[U] {
   val eventListeners: List[EventListener[U]]
 
   val userService: UserService[U]
+
+  implicit def executionContext: ExecutionContext
 }
 
 object RuntimeEnvironment {
@@ -54,8 +57,8 @@ object RuntimeEnvironment {
     override lazy val passwordHashers: Map[String, PasswordHasher] = Map(currentHasher.id -> currentHasher)
     override lazy val passwordValidator: PasswordValidator = new PasswordValidator.Default()
 
-    override lazy val httpService: HttpService = new HttpService.Default()
-    override lazy val cacheService: CacheService = new CacheService.Default()
+    override lazy val httpService: HttpService = new HttpService.Default
+    override lazy val cacheService: CacheService = new CacheService.Default
     override lazy val avatarService: Option[AvatarService] = Some(new AvatarService.Default(httpService))
     override lazy val idGenerator: IdGenerator = new IdGenerator.Default()
 
@@ -65,6 +68,8 @@ object RuntimeEnvironment {
     )
 
     override lazy val eventListeners: List[EventListener[U]] = List()
+    override implicit val executionContext: ExecutionContext =
+      ExecutionContext.Implicits.global
 
     protected def include(p: IdentityProvider) = p.id -> p
     protected def oauth1ClientFor(provider: String) = new OAuth1Client.Default(ServiceInfoHelper.forProvider(provider), httpService)

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -101,7 +101,10 @@ trait SecureSocial[U] extends Controller {
    * @param authorize an Authorize object that checks if the user is authorized to invoke the action
    */
   class SecuredActionBuilder(authorize: Option[Authorization[U]] = None)
-    extends ActionBuilder[({ type R[A] = SecuredRequest[A] })#R] {
+      extends ActionBuilder[({ type R[A] = SecuredRequest[A] })#R] {
+
+    override protected def executionContext: ExecutionContext = env.executionContext
+
     private val logger = play.api.Logger("securesocial.core.SecuredActionBuilder")
 
     def invokeSecuredBlock[A](authorize: Option[Authorization[U]], request: Request[A],
@@ -147,6 +150,8 @@ trait SecureSocial[U] extends Controller {
    * The UserAwareAction builder
    */
   class UserAwareActionBuilder extends ActionBuilder[({ type R[A] = RequestWithUser[A] })#R] {
+    override protected def executionContext: ExecutionContext = env.executionContext
+
     override def invokeBlock[A](request: Request[A],
       block: (RequestWithUser[A]) => Future[Result]): Future[Result] =
       {

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -34,7 +34,7 @@ import play.api.mvc.Result
  */
 trait SecureSocial[U] extends Controller {
   implicit val env: RuntimeEnvironment[U]
-  implicit val executionContext: ExecutionContext = env.executionContext
+  implicit def executionContext: ExecutionContext = env.executionContext
 
   /**
    * A Forbidden response for ajax clients

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -34,6 +34,7 @@ import play.api.mvc.Result
  */
 trait SecureSocial[U] extends Controller {
   implicit val env: RuntimeEnvironment[U]
+  implicit val executionContext: ExecutionContext = env.executionContext
 
   /**
    * A Forbidden response for ajax clients
@@ -100,13 +101,13 @@ trait SecureSocial[U] extends Controller {
    * @param authorize an Authorize object that checks if the user is authorized to invoke the action
    */
   class SecuredActionBuilder(authorize: Option[Authorization[U]] = None)
-      extends ActionBuilder[({ type R[A] = SecuredRequest[A] })#R] {
+    extends ActionBuilder[({ type R[A] = SecuredRequest[A] })#R] {
     private val logger = play.api.Logger("securesocial.core.SecuredActionBuilder")
 
     def invokeSecuredBlock[A](authorize: Option[Authorization[U]], request: Request[A],
       block: SecuredRequest[A] => Future[Result]): Future[Result] =
       {
-        import ExecutionContext.Implicits.global
+        implicit val ec = executionContext
         env.authenticatorService.fromRequest(request).flatMap {
           case Some(authenticator) if authenticator.isValid =>
             authenticator.touch.flatMap { updatedAuthenticator =>
@@ -121,7 +122,6 @@ trait SecureSocial[U] extends Controller {
             }
           case Some(authenticator) if !authenticator.isValid =>
             logger.debug("[securesocial] user tried to access with invalid authenticator : '%s'".format(request.uri))
-            import ExecutionContext.Implicits.global
             notAuthenticatedResult(request).flatMap { _.discardingAuthenticator(authenticator) }
           case None =>
             logger.debug("[securesocial] anonymous user trying to access : '%s'".format(request.uri))
@@ -150,7 +150,7 @@ trait SecureSocial[U] extends Controller {
     override def invokeBlock[A](request: Request[A],
       block: (RequestWithUser[A]) => Future[Result]): Future[Result] =
       {
-        import ExecutionContext.Implicits.global
+        implicit val ec = executionContext
         env.authenticatorService.fromRequest(request).flatMap {
           case Some(authenticator) if authenticator.isValid =>
             authenticator.touch.flatMap {
@@ -219,7 +219,7 @@ object SecureSocial {
    * @tparam U the user type
    * @return a future with an option user
    */
-  def currentUser[U](implicit request: RequestHeader, env: RuntimeEnvironment[U], ec: ExecutionContext): Future[Option[U]] = {
+  def currentUser[U](implicit request: RequestHeader, env: RuntimeEnvironment[U], executionContext: ExecutionContext): Future[Option[U]] = {
     env.authenticatorService.fromRequest.map {
       case Some(authenticator) if authenticator.isValid => Some(authenticator.user)
       case _ => None

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -103,14 +103,13 @@ trait SecureSocial[U] extends Controller {
   class SecuredActionBuilder(authorize: Option[Authorization[U]] = None)
       extends ActionBuilder[({ type R[A] = SecuredRequest[A] })#R] {
 
-    override protected def executionContext: ExecutionContext = env.executionContext
+    override protected implicit def executionContext: ExecutionContext = env.executionContext
 
     private val logger = play.api.Logger("securesocial.core.SecuredActionBuilder")
 
     def invokeSecuredBlock[A](authorize: Option[Authorization[U]], request: Request[A],
       block: SecuredRequest[A] => Future[Result]): Future[Result] =
       {
-        implicit val ec = executionContext
         env.authenticatorService.fromRequest(request).flatMap {
           case Some(authenticator) if authenticator.isValid =>
             authenticator.touch.flatMap { updatedAuthenticator =>
@@ -150,12 +149,11 @@ trait SecureSocial[U] extends Controller {
    * The UserAwareAction builder
    */
   class UserAwareActionBuilder extends ActionBuilder[({ type R[A] = RequestWithUser[A] })#R] {
-    override protected def executionContext: ExecutionContext = env.executionContext
+    override protected implicit def executionContext: ExecutionContext = env.executionContext
 
     override def invokeBlock[A](request: Request[A],
       block: (RequestWithUser[A]) => Future[Result]): Future[Result] =
       {
-        implicit val ec = executionContext
         env.authenticatorService.fromRequest(request).flatMap {
           case Some(authenticator) if authenticator.isValid =>
             authenticator.touch.flatMap {

--- a/module-code/app/securesocial/core/authenticator/AuthenticatorStore.scala
+++ b/module-code/app/securesocial/core/authenticator/AuthenticatorStore.scala
@@ -68,7 +68,7 @@ object AuthenticatorStore {
    * @tparam A the Authenticator type
    */
   class Default[A <: Authenticator[_]](cacheService: CacheService)(implicit override val executionContext: ExecutionContext)
-    extends AuthenticatorStore[A] {
+      extends AuthenticatorStore[A] {
     /**
      * Retrieves an Authenticator from the cache
      *

--- a/module-code/app/securesocial/core/authenticator/AuthenticatorStore.scala
+++ b/module-code/app/securesocial/core/authenticator/AuthenticatorStore.scala
@@ -51,6 +51,13 @@ trait AuthenticatorStore[A <: Authenticator[_]] {
    * @return a future of Unit
    */
   def delete(id: String): Future[Unit]
+
+  /**
+   * Provides an execution context for asynchronous actions, possibly overriding the default global context
+   *
+   * @return an ExecutionContext
+   */
+  implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
 }
 
 object AuthenticatorStore {
@@ -60,7 +67,8 @@ object AuthenticatorStore {
    * @param cacheService the cache service to use
    * @tparam A the Authenticator type
    */
-  class Default[A <: Authenticator[_]](cacheService: CacheService) extends AuthenticatorStore[A] {
+  class Default[A <: Authenticator[_]](cacheService: CacheService)(implicit override val executionContext: ExecutionContext)
+    extends AuthenticatorStore[A] {
     /**
      * Retrieves an Authenticator from the cache
      *
@@ -80,7 +88,6 @@ object AuthenticatorStore {
      * @return the saved authenticator
      */
     override def save(authenticator: A, timeoutInSeconds: Int): Future[A] = {
-      import ExecutionContext.Implicits.global
       cacheService.set(authenticator.id, authenticator, timeoutInSeconds).map { _ => authenticator }
     }
 

--- a/module-code/app/securesocial/core/authenticator/AuthenticatorStore.scala
+++ b/module-code/app/securesocial/core/authenticator/AuthenticatorStore.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
  *
  * @tparam A the Authenticator type the store manages
  */
-trait AuthenticatorStore[A <: Authenticator[_]] {
+abstract class AuthenticatorStore[A <: Authenticator[_]](implicit val executionContext: ExecutionContext) {
   /**
    * Retrieves an Authenticator from the backing store
    *
@@ -51,13 +51,6 @@ trait AuthenticatorStore[A <: Authenticator[_]] {
    * @return a future of Unit
    */
   def delete(id: String): Future[Unit]
-
-  /**
-   * Provides an execution context for asynchronous actions, possibly overriding the default global context
-   *
-   * @return an ExecutionContext
-   */
-  implicit def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
 }
 
 object AuthenticatorStore {
@@ -67,8 +60,9 @@ object AuthenticatorStore {
    * @param cacheService the cache service to use
    * @tparam A the Authenticator type
    */
-  class Default[A <: Authenticator[_]](cacheService: CacheService)(implicit override val executionContext: ExecutionContext)
+  class Default[A <: Authenticator[_]](cacheService: CacheService)(implicit executionContext: ExecutionContext)
       extends AuthenticatorStore[A] {
+      
     /**
      * Retrieves an Authenticator from the cache
      *

--- a/module-code/app/securesocial/core/authenticator/StoreBackedAuthenticator.scala
+++ b/module-code/app/securesocial/core/authenticator/StoreBackedAuthenticator.scala
@@ -34,6 +34,9 @@ trait StoreBackedAuthenticator[U, T <: Authenticator[U]] extends Authenticator[U
   @(transient @getter)
   val store: AuthenticatorStore[T]
 
+  @transient
+  implicit val executionContext = store.executionContext
+
   /**
    * The time an authenticator is allowed to live in the store
    */
@@ -137,7 +140,6 @@ trait StoreBackedAuthenticator[U, T <: Authenticator[U]] extends Authenticator[U
    * @return the result modified to signal the authenticator is no longer valid
    */
   override def discarding(result: Result): Future[Result] = {
-    import ExecutionContext.Implicits.global
     store.delete(id).map { _ => result }
   }
 
@@ -148,7 +150,6 @@ trait StoreBackedAuthenticator[U, T <: Authenticator[U]] extends Authenticator[U
    * @return the current http context modified to signal the authenticator is no longer valid
    */
   override def discarding(javaContext: play.mvc.Http.Context): Future[Unit] = {
-    import ExecutionContext.Implicits.global
     store.delete(id).map { _ => () }
   }
 }

--- a/module-code/app/securesocial/core/providers/ConcurProvider.scala
+++ b/module-code/app/securesocial/core/providers/ConcurProvider.scala
@@ -24,7 +24,6 @@ import play.api.mvc.Request
 import securesocial.core.{ AuthenticationException, BasicProfile, OAuth2Client, OAuth2Constants, OAuth2Info, OAuth2Provider }
 import securesocial.core.services.{ CacheService, RoutesService }
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.xml.Node
 
@@ -54,7 +53,7 @@ class ConcurProvider(routesService: RoutesService,
    * Unfortunately, Concur does not stick to the OAuth2 spec saying that a HTTP POST must be
    * used to get the access token. Instead, a HTTP GET is used in their implementation.
    */
-  override def getAccessToken[A](code: String)(implicit request: Request[A], ec: ExecutionContext): Future[OAuth2Info] = {
+  override def getAccessToken[A](code: String)(implicit request: Request[A]): Future[OAuth2Info] = {
     val url = settings.accessTokenUrl + "?" + OAuth2Constants.Code + "=" + code + "&" +
       OAuth2Constants.ClientId + "=" + settings.clientId + "&" +
       OAuth2Constants.ClientSecret + "=" + settings.clientSecret

--- a/module-code/app/securesocial/core/providers/DropboxProvider.scala
+++ b/module-code/app/securesocial/core/providers/DropboxProvider.scala
@@ -36,7 +36,6 @@ class DropboxProvider(routesService: RoutesService,
   override val id = DropboxProvider.Dropbox
 
   override def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     import play.api.Play.current
 
     val accessToken = info.accessToken

--- a/module-code/app/securesocial/core/providers/FacebookProvider.scala
+++ b/module-code/app/securesocial/core/providers/FacebookProvider.scala
@@ -59,7 +59,6 @@ class FacebookProvider(routesService: RoutesService,
   }
 
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val accessToken = info.accessToken
     client.retrieveProfile(MeApi + accessToken).map { me =>
       (me \ Error).asOpt[JsObject] match {

--- a/module-code/app/securesocial/core/providers/FoursquareProvider.scala
+++ b/module-code/app/securesocial/core/providers/FoursquareProvider.scala
@@ -47,7 +47,6 @@ class FoursquareProvider(routesService: RoutesService,
   override val id = FoursquareProvider.Foursquare
 
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     client.retrieveProfile(GetAuthenticatedUser.format(info.accessToken)).map { me =>
       (me \ "response" \ "user").asOpt[String] match {
         case Some(msg) =>

--- a/module-code/app/securesocial/core/providers/GitHubProvider.scala
+++ b/module-code/app/securesocial/core/providers/GitHubProvider.scala
@@ -58,7 +58,6 @@ class GitHubProvider(routesService: RoutesService,
   }
 
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     client.retrieveProfile(GetAuthenticatedUser.format(info.accessToken)).map { me =>
       (me \ Message).asOpt[String] match {
         case Some(msg) =>

--- a/module-code/app/securesocial/core/providers/GoogleProvider.scala
+++ b/module-code/app/securesocial/core/providers/GoogleProvider.scala
@@ -48,7 +48,6 @@ class GoogleProvider(routesService: RoutesService,
   override val id = GoogleProvider.Google
 
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val accessToken = info.accessToken
     client.retrieveProfile(UserInfoApi + accessToken).map { me =>
       (me \ Error).asOpt[JsObject] match {

--- a/module-code/app/securesocial/core/providers/InstagramProvider.scala
+++ b/module-code/app/securesocial/core/providers/InstagramProvider.scala
@@ -41,7 +41,6 @@ class InstagramProvider(routesService: RoutesService,
   override val id = InstagramProvider.Instagram
 
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     client.retrieveProfile(GetAuthenticatedUser.format(info.accessToken)).map { me =>
       (me \ "response" \ "user").asOpt[String] match {
         case Some(msg) => {

--- a/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
+++ b/module-code/app/securesocial/core/providers/LinkedInOAuth2Provider.scala
@@ -32,7 +32,6 @@ class LinkedInOAuth2Provider(routesService: RoutesService,
   override val id = LinkedInOAuth2Provider.LinkedIn
 
   override def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val accessToken = info.accessToken
     client.retrieveProfile(LinkedInOAuth2Provider.Api + accessToken).map { me =>
       (me \ ErrorCode).asOpt[Int] match {

--- a/module-code/app/securesocial/core/providers/LinkedInProvider.scala
+++ b/module-code/app/securesocial/core/providers/LinkedInProvider.scala
@@ -38,7 +38,6 @@ class LinkedInProvider(
   override val id = LinkedInProvider.LinkedIn
 
   override def fillProfile(info: OAuth1Info): Future[BasicProfile] = {
-    import ExecutionContext.Implicits.global
     client.retrieveProfile(LinkedInProvider.Api, info).map { me =>
       (me \ ErrorCode).asOpt[Int] match {
         case Some(error) => {

--- a/module-code/app/securesocial/core/providers/SoundcloudProvider.scala
+++ b/module-code/app/securesocial/core/providers/SoundcloudProvider.scala
@@ -42,7 +42,6 @@ class SoundcloudProvider(routesService: RoutesService,
   override val id = SoundcloudProvider.Soundcloud
 
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val accessToken = info.accessToken
     client.retrieveProfile(UserInfoApi + accessToken).map { me =>
       (me \ Error).asOpt[JsObject] match {

--- a/module-code/app/securesocial/core/providers/TwitterProvider.scala
+++ b/module-code/app/securesocial/core/providers/TwitterProvider.scala
@@ -37,7 +37,6 @@ class TwitterProvider(
   override val id = TwitterProvider.Twitter
 
   override def fillProfile(info: OAuth1Info): Future[BasicProfile] = {
-    import ExecutionContext.Implicits.global
     client.retrieveProfile(TwitterProvider.VerifyCredentials, info).map { me =>
       val userId = (me \ Id).as[String]
       val name = (me \ Name).asOpt[String]

--- a/module-code/app/securesocial/core/providers/UsernamePasswordProvider.scala
+++ b/module-code/app/securesocial/core/providers/UsernamePasswordProvider.scala
@@ -36,6 +36,7 @@ class UsernamePasswordProvider[U](userService: UserService[U],
   avatarService: Option[AvatarService],
   viewTemplates: ViewTemplates,
   passwordHashers: Map[String, PasswordHasher])
+  (implicit val executionContext: ExecutionContext)
     extends IdentityProvider with ApiSupport with Controller {
 
   override val id = UsernamePasswordProvider.UsernamePassword
@@ -52,7 +53,7 @@ class UsernamePasswordProvider[U](userService: UserService[U],
     doAuthentication()
   }
 
-  private def profileForCredentials(userId: String, password: String)(implicit ec: ExecutionContext): Future[Option[BasicProfile]] = {
+  private def profileForCredentials(userId: String, password: String): Future[Option[BasicProfile]] = {
     userService.find(id, userId).map { maybeUser =>
       for (
         user <- maybeUser;
@@ -71,7 +72,7 @@ class UsernamePasswordProvider[U](userService: UserService[U],
       NavigationFlow(badRequest(UsernamePasswordProvider.loginForm, Some(InvalidCredentials)))
   }
 
-  protected def withUpdatedAvatar(profile: BasicProfile)(implicit ec: ExecutionContext): Future[BasicProfile] = {
+  protected def withUpdatedAvatar(profile: BasicProfile): Future[BasicProfile] = {
     (avatarService, profile.email) match {
       case (Some(service), Some(e)) => service.urlFor(e).map {
         case url if url != profile.avatarUrl => profile.copy(avatarUrl = url)
@@ -82,7 +83,6 @@ class UsernamePasswordProvider[U](userService: UserService[U],
   }
 
   private def doAuthentication[A](apiMode: Boolean = false)(implicit request: Request[A]): Future[AuthenticationResult] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val form = UsernamePasswordProvider.loginForm.bindFromRequest()
     form.fold(
       errors => Future.successful {

--- a/module-code/app/securesocial/core/providers/UsernamePasswordProvider.scala
+++ b/module-code/app/securesocial/core/providers/UsernamePasswordProvider.scala
@@ -35,8 +35,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 class UsernamePasswordProvider[U](userService: UserService[U],
   avatarService: Option[AvatarService],
   viewTemplates: ViewTemplates,
-  passwordHashers: Map[String, PasswordHasher])
-  (implicit val executionContext: ExecutionContext)
+  passwordHashers: Map[String, PasswordHasher])(implicit val executionContext: ExecutionContext)
     extends IdentityProvider with ApiSupport with Controller {
 
   override val id = UsernamePasswordProvider.UsernamePassword

--- a/module-code/app/securesocial/core/providers/VkProvider.scala
+++ b/module-code/app/securesocial/core/providers/VkProvider.scala
@@ -26,7 +26,6 @@ class VkProvider(routesService: RoutesService,
   override val id = VkProvider.Vk
 
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val accessToken = info.accessToken
     client.retrieveProfile(GetProfilesApi + accessToken).map { json =>
       (json \ Error).asOpt[JsObject] match {

--- a/module-code/app/securesocial/core/providers/WeiboProvider.scala
+++ b/module-code/app/securesocial/core/providers/WeiboProvider.scala
@@ -69,7 +69,6 @@ class WeiboProvider(routesService: RoutesService,
    * @return A copy of the user object with the new values set
    */
   def fillProfile(info: OAuth2Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val accessToken = info.accessToken
 
     val weiboUserId = info.tokenType.getOrElse {
@@ -97,7 +96,7 @@ class WeiboProvider(routesService: RoutesService,
     }
   }
 
-  def getEmail(accessToken: String)(implicit ec: ExecutionContext): Future[Option[String]] = {
+  def getEmail(accessToken: String): Future[Option[String]] = {
     import play.api.Play.current
     WS.url(GetUserEmail.format(accessToken)).get().map { response =>
       val me = response.json

--- a/module-code/app/securesocial/core/providers/XingProvider.scala
+++ b/module-code/app/securesocial/core/providers/XingProvider.scala
@@ -29,15 +29,12 @@ import scala.concurrent.Future
 class XingProvider(
   routesService: RoutesService,
   cacheService: CacheService,
-  client: OAuth1Client) extends OAuth1Provider(
-  routesService,
-  cacheService,
-  client
-) {
+  client: OAuth1Client)
+    extends OAuth1Provider(routesService, cacheService, client) {
+
   override val id = XingProvider.Xing
 
   override def fillProfile(info: OAuth1Info): Future[BasicProfile] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
     client.retrieveProfile(XingProvider.VerifyCredentials, info).map { json =>
       val me = (json \ Users).as[Seq[JsObject]].head
       val userId = (me \ Id).as[String]

--- a/module-code/app/securesocial/core/services/AuthenticatorService.scala
+++ b/module-code/app/securesocial/core/services/AuthenticatorService.scala
@@ -22,7 +22,7 @@ import securesocial.core.authenticator.{ Authenticator, AuthenticatorBuilder }
 import scala.reflect.ClassTag
 import org.apache.commons.lang3.reflect.TypeUtils
 
-class AuthenticatorService[U](builders: AuthenticatorBuilder[U]*) {
+class AuthenticatorService[U](builders: AuthenticatorBuilder[U]*)(implicit val executionContext: ExecutionContext) {
   val asMap = builders.map { builder => builder.id -> builder }.toMap
 
   def find(id: String): Option[AuthenticatorBuilder[U]] = {
@@ -36,8 +36,6 @@ class AuthenticatorService[U](builders: AuthenticatorBuilder[U]*) {
   }
 
   def fromRequest(implicit request: RequestHeader): Future[Option[Authenticator[U]]] = {
-    import ExecutionContext.Implicits.global
-
     def iterateIt(seq: Seq[AuthenticatorBuilder[U]]): Future[Option[Authenticator[U]]] = {
       if (seq.isEmpty)
         Future.successful(None)

--- a/module-code/app/securesocial/core/services/AvatarService.scala
+++ b/module-code/app/securesocial/core/services/AvatarService.scala
@@ -31,7 +31,7 @@ object AvatarService {
    * A default implemtation
    * @param httpService
    */
-  class Default(httpService: HttpService) extends AvatarService {
+  class Default(httpService: HttpService)(implicit val executionContext: ExecutionContext) extends AvatarService {
     import _root_.java.security.MessageDigest
 
     private val logger = play.api.Logger("securesocial.core.providers.utils.AvatarService.Default")
@@ -40,7 +40,6 @@ object AvatarService {
     val Md5 = "MD5"
 
     override def urlFor(userId: String): Future[Option[String]] = {
-      import ExecutionContext.Implicits.global
       hash(userId).map(hash => {
         val url = GravatarUrl.format(hash)
         httpService.url(url).get().map { response =>

--- a/module-code/app/securesocial/core/services/CacheService.scala
+++ b/module-code/app/securesocial/core/services/CacheService.scala
@@ -16,7 +16,7 @@
  */
 package securesocial.core.services
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * An interface for the Cache API
@@ -37,7 +37,7 @@ object CacheService {
   /**
    * A default implementation for the CacheService based on the Play cache.
    */
-  class Default extends CacheService {
+  class Default(implicit val executionContext: ExecutionContext) extends CacheService {
     import play.api.cache.Cache
     import scala.reflect.ClassTag
     import play.api.Play.current

--- a/module-code/app/securesocial/core/services/HttpService.scala
+++ b/module-code/app/securesocial/core/services/HttpService.scala
@@ -16,6 +16,8 @@
  */
 package securesocial.core.services
 
+import scala.concurrent.ExecutionContext
+
 /**
  * A mockable interface for the http client
  */
@@ -30,7 +32,7 @@ object HttpService {
   /**
    * A default implementation for HttpService based on the Play WS client.
    */
-  class Default extends HttpService {
+  class Default(implicit val executionContext: ExecutionContext) extends HttpService {
     import play.api.Play.current
     import play.api.libs.ws.WS
     import play.api.libs.ws.WSRequestHolder

--- a/samples/scala/demo/app/Global.scala
+++ b/samples/scala/demo/app/Global.scala
@@ -25,6 +25,7 @@ object Global extends play.api.GlobalSettings {
    * The runtime environment for this sample app.
    */
   object MyRuntimeEnvironment extends RuntimeEnvironment.Default[DemoUser] {
+    override implicit val executionContext = play.api.libs.concurrent.Execution.defaultContext
     override lazy val routes = new CustomRoutesService()
     override lazy val userService: InMemoryUserService = new InMemoryUserService()
     override lazy val eventListeners = List(new MyEventListener())

--- a/samples/scala/demo/app/controllers/Application.scala
+++ b/samples/scala/demo/app/controllers/Application.scala
@@ -38,7 +38,6 @@ class Application(override implicit val env: RuntimeEnvironment[DemoUser]) exten
    * Sample use of SecureSocial.currentUser. Access the /current-user to test it
    */
   def currentUser = Action.async { implicit request =>
-    import play.api.libs.concurrent.Execution.Implicits._
     SecureSocial.currentUser[DemoUser].map { maybeUser =>
       val userId = maybeUser.map(_.main.userId).getOrElse("unknown")
       Ok(s"Your id is $userId")


### PR DESCRIPTION
The default execution context (scala.concurrent.ExecutionContext.global)
was hardcoded in multiple places in the code. This is not only
inflexible, but problematic for Play applications, since it will cause
code inside futures to not use the expected environment, like the custom
class loader.

As as solution, introduce an executionContext member to
RuntimeEnvironment, defaulting to the global context, that can be
overridden by users as desired.

Services that need the contexts have been refactored to receive them
once as a constructor parameter in their default implementations, or
whenever possible, take them from another parameter that already has one
(like another service). The only service that was not linked to any
other and needs it's own definition of executionContext is
AuthenticatorStore. To mitigate issues, it will get a context from the
environment in the default implementation (through an implicit
parameter), or default to the global context if not other override
exists