### PR TITLE
enable use of referer if user is already authenticated

### DIFF
--- a/module-code/app/securesocial/controllers/LoginPage.scala
+++ b/module-code/app/securesocial/controllers/LoginPage.scala
@@ -48,9 +48,15 @@ trait BaseLoginPage[U] extends SecureSocial[U] {
    */
   def login = CSRFAddToken {
     UserAwareAction { implicit request =>
-      val to = ProviderControllerHelper.landingUrl
       if (request.user.isDefined) {
-        // if the user is already logged in just redirect to the app
+        // if the user is already logged in, a referer is set and we handle the
+        // referer the same way as an OriginalUrl in the session, we redirect back
+        // to this URL. Otherwise, just redirect to the application's landing page
+        val to = (if (SecureSocial.enableRefererAsOriginalUrl) {
+          SecureSocial.refererPathAndQuery
+        } else {
+          None
+        }).getOrElse(ProviderControllerHelper.landingUrl)
         logger.debug("User already logged in, skipping login page. Redirecting to %s".format(to))
         Redirect(to)
       } else {

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -195,15 +195,25 @@ object SecureSocial {
       // login, switches to signup and goes back to login we want to keep the first referer
       case Some(_) => result
       case None => {
-        request.headers.get(HeaderNames.REFERER).map { referer =>
-          // we don't want to use the ful referer, as then we might redirect from https
-          // back to http and loose our session. So let's get the path and query string only
-          val idxFirstSlash = referer.indexOf("/", "https://".length())
-          val refererUri = if (idxFirstSlash < 0) "/" else referer.substring(idxFirstSlash)
+        refererPathAndQuery.map { referer =>
           result.withSession(
-            request.session + (OriginalUrlKey -> refererUri))
+            request.session + (OriginalUrlKey -> referer))
         }.getOrElse(result)
       }
+    }
+  }
+
+  /**
+   * Gets the referer URI from the implicit request
+   * @return the path and query string of the referer path and query
+   */
+  def refererPathAndQuery[A](implicit request: Request[A]): Option[String] = {
+    request.headers.get(HeaderNames.REFERER).map { referer =>
+      // we don't want to use the full referer, as then we might redirect from https
+      // back to http and loose our session. So let's get the path and query string only
+      val idxFirstSlash = referer.indexOf("/", "https://".length())
+      val refererUri = if (idxFirstSlash < 0) "/" else referer.substring(idxFirstSlash)
+      refererUri
     }
   }
 

--- a/samples/scala/demo/app/views/linkResult.scala.html
+++ b/samples/scala/demo/app/views/linkResult.scala.html
@@ -46,4 +46,5 @@
 </div>
 
 <a class="btn" href="/">Ok</a>
+<a class="btn" href="@securesocial.controllers.routes.LoginPage.login()">Login</a>
 }


### PR DESCRIPTION
The following use-case was not supported so far and can happen in a
productive environment with enabled HTTPS support.

1. User authenticates
2. User goes to a resource using http (instead of https) by either
entering a URL or by clicking on an absolute link. Let’s say
http://domain.com/some/public/resource
3. Since HTTP is used, the user is not authenticated. User clicks on
“Login” to authenticate
4. Since the user is already authenticated from step 1. he/she is
redirected to /. Expected would be that the user is redirected to
https://domain.com/some/public/resource

Fix:
There already was a feature that the referer is used (see config
securesocial.SecureSocial.enableRefererAsOriginalUrl). This feature was
only applied if the user was not yet authenticated. This commit enables
the same logic for authenticated users.

Testing:
Make sure the feature is enabled (config property `securesocial.
enableRefererAsOriginalUrl = true`)
1.  go to http://localhost/current-link
2. authenticate
3. click on “login” to do a second login attempt
4. you should be redirected to /current-link again