### PR TITLE
Use plugable not authorized page

### DIFF
--- a/module-code/app/securesocial/controllers/ViewsPlugin.scala
+++ b/module-code/app/securesocial/controllers/ViewsPlugin.scala
@@ -161,7 +161,7 @@ object ViewTemplates {
       securesocial.views.html.passwordChange(form)
     }
 
-    def getNotAuthorizedPage(implicit request: RequestHeader, lang: Lang): Html = {
+    override def getNotAuthorizedPage(implicit request: RequestHeader, lang: Lang): Html = {
       securesocial.views.html.notAuthorized()
     }
   }

--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -44,7 +44,7 @@ trait SecureSocial[U] extends Controller {
    */
   protected val notAuthenticatedJson = Unauthorized(Json.toJson(Map("error" -> "Credentials required"))).as(JSON)
   protected val notAuthorizedJson = Forbidden(Json.toJson(Map("error" -> "Not authorized"))).as(JSON)
-  protected def notAuthorizedPage()(implicit request: RequestHeader): Html = securesocial.views.html.notAuthorized()
+  protected def notAuthorizedPage()(implicit request: RequestHeader): Html = env.viewTemplates.getNotAuthorizedPage
 
   protected def notAuthenticatedResult[A](implicit request: Request[A]): Future[Result] = {
     Future.successful {


### PR DESCRIPTION
Previously was hardcoded to the securesocial implementation.  Now allowing
custom not authorized pages to be rendered.

Fixes #499 

------
Note that I've tested this manually by publishing and using from my application which is using securesocial.  I wasn't able to get the securesocial unit tests running.  Invoking `sbt test` with a fresh clone of master resulted in compilation errors in the sample projects.  Can you please document how the tests should be run.

eg 
```
[error] C:\developer\workspace\securesocial\samples\scala\demo\test\ApplicationSpec.scala:6: object testkit is not a member of package securesocial
[error] import securesocial.testkit.WithLoggedUser
```

Even if I limit to the core tests with `sbt "project core" test` some tests fail to pass?  Is this correct or something broken in my setup?
```
[info] GoogleLoginSpec
[info]
[info] an application using secure social should
[info] x log a valid google user
[error]    'Some(http:///login)' is not equal to 'Some(/)' (GoogleLoginSpec.scala:61)
```

Thanks