### PR TITLE
Make SecuredRequest and RequestWithUser path independent

### DIFF
--- a/module-code/app/securesocial/controllers/PasswordChange.scala
+++ b/module-code/app/securesocial/controllers/PasswordChange.scala
@@ -17,6 +17,7 @@
 package securesocial.controllers
 
 import securesocial.core._
+import securesocial.core.SecureSocial._
 import play.api.mvc.Result
 import play.api.Play
 import play.api.data.Form
@@ -65,7 +66,7 @@ trait BasePasswordChange[U] extends SecureSocial[U] {
    * @tparam A the type of the user object
    * @return a future boolean
    */
-  def checkCurrentPassword[A](suppliedPassword: String)(implicit request: SecuredRequest[A]): Future[Boolean] = {
+  def checkCurrentPassword[A](suppliedPassword: String)(implicit request: SecuredRequest[A, U]): Future[Boolean] = {
     env.userService.passwordInfoFor(request.user).map {
       case Some(info) =>
         env.passwordHashers.get(info.hasher).exists {
@@ -75,7 +76,7 @@ trait BasePasswordChange[U] extends SecureSocial[U] {
     }
   }
 
-  private def execute[A](f: Form[ChangeInfo] => Future[Result])(implicit request: SecuredRequest[A]): Future[Result] = {
+  private def execute[A](f: Form[ChangeInfo] => Future[Result])(implicit request: SecuredRequest[A, U]): Future[Result] = {
     val form = Form[ChangeInfo](
       mapping(
         CurrentPassword ->


### PR DESCRIPTION
Thanks for the great module, first of all.

I'm not sure this is intended or not, but currently `SecuredRequest` and `RequestWithUser` are path dependent, and it's hard (for our project) to use them in a view (more precisely layout) used across multiple pages.

Suppose the following scenario.

We have the following two controllers:

```scala
class ControllerOne(override implicit val env: RuntimeEnvironment[User]) extends SecureSocial[User] {
  def foo() = SecuredAction { implicit request =>
    Ok(views.html.c1.foo())
  }
}

class ControllerTwo(override implicit val env: RuntimeEnvironment[User]) extends SecureSocial[User] {
  def bar() = SecuredAction { implicit request =>
    Ok(views.html.c2.bar())
  }
}
```

Also, a layout file like the following:

```scala
@(title: String)(content: Html)
<!DOCTYPE html>
<html>
  <head><title>@title</title></head>
  <body>
    <div>Hello, my friend</div>
    <div class="wrapper">@content</div>
  </body>
</html>
```

And the view files like this:

```scala
// foo.scala.html
@()
@main("page foo") {
  foo foo
}

// bar.scala.html
@()
@main("page bar") {
  bar bar
}
```

Now, I'd like to show the user name in the layout like the following, but this doesn't compile because `SecuredRequest` is path dependent:

```scala
@(title: String)(content: Html)(implicit request: SecuredRequest[AnyContent])
@** SecuredRequest could be either ControllerOne#SecuredRequest or ControllerTwo#SecuredRequest **@
<!DOCTYPE html>
<html>
  <head><title>@title</title></head>
  <body>
    <div>Hello, @request.user.name</div>
    <div class="wrapper">@content</div>
  </body>
</html>
```

This PR will make the classes path independent. If you actually intended to make them path dependent for some reason, you could just reject this PR. It would be nice if you could explain the rationale though.

Thanks.