### PR TITLE
Fixed url to get authenticated user on Foursquare provider

### DIFF
--- a/module-code/app/securesocial/core/providers/FoursquareProvider.scala
+++ b/module-code/app/securesocial/core/providers/FoursquareProvider.scala
@@ -29,7 +29,7 @@ class FoursquareProvider(routesService: RoutesService,
   cacheService: CacheService,
   client: OAuth2Client)
     extends OAuth2Provider(routesService, client, cacheService) {
-  val GetAuthenticatedUser = "https://api.foursquare.com/v2/users/self?v=20140404oauth_token=%s"
+  val GetAuthenticatedUser = "https://api.foursquare.com/v2/users/self?v=20140404&oauth_token=%s"
   val AccessToken = "access_token"
   val TokenType = "token_type"
   val Message = "message"


### PR DESCRIPTION
The url to get information about the authenticated user is missing a &. Without it, the authentication of this request will obviously fail and the information about the user cannot be retrieved.