### PR TITLE
Fix OnStartSignupGoTo and OnSignUpGoTo config urls

### DIFF
--- a/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
+++ b/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
@@ -42,6 +42,8 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
   val DefaultDuration = 60
   val TokenDuration = Play.current.configuration.getInt(TokenDurationKey).getOrElse(DefaultDuration)
 
+  lazy val conf = play.api.Play.current.configuration
+
   val startForm = Form(
     Email -> email.verifying(nonEmpty)
   )
@@ -88,7 +90,8 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
    * @param request the current request
    * @return the action result
    */
-  protected def handleStartResult()(implicit request: RequestHeader): Result = Redirect(env.routes.loginPageUrl)
+  protected def handleStartResult()(implicit request: RequestHeader): Result = 
+    Redirect(conf.getString("securesocial.onStartSignUpGoTo").getOrElse(env.routes.loginPageUrl))
 
   /**
    * The result sent after the operation has been completed by the user

--- a/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
+++ b/module-code/app/securesocial/controllers/MailTokenBasedOperations.scala
@@ -41,8 +41,8 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
   val TokenDurationKey = "securesocial.userpass.tokenDuration"
   val DefaultDuration = 60
   val TokenDuration = Play.current.configuration.getInt(TokenDurationKey).getOrElse(DefaultDuration)
-
-  lazy val conf = play.api.Play.current.configuration
+  val OnStartSignUpGoToKey = "securesocial.onStartSignUpGoTo"
+  val OnSignUpGoToKey = "securesocial.onSignUpGoTo"
 
   val startForm = Form(
     Email -> email.verifying(nonEmpty)
@@ -90,8 +90,8 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
    * @param request the current request
    * @return the action result
    */
-  protected def handleStartResult()(implicit request: RequestHeader): Result = 
-    Redirect(conf.getString("securesocial.onStartSignUpGoTo").getOrElse(env.routes.loginPageUrl))
+  protected def handleStartResult()(implicit request: RequestHeader): Result =
+    Redirect(Play.current.configuration.getString(OnStartSignUpGoToKey).getOrElse(env.routes.loginPageUrl))
 
   /**
    * The result sent after the operation has been completed by the user
@@ -99,5 +99,6 @@ abstract class MailTokenBasedOperations[U] extends SecureSocial[U] {
    * @param request the current request
    * @return the action result
    */
-  protected def confirmationResult()(implicit request: RequestHeader): Result = Redirect(env.routes.loginPageUrl)
+  protected def confirmationResult()(implicit request: RequestHeader): Result =
+    Redirect(Play.current.configuration.getString(OnSignUpGoToKey).getOrElse(env.routes.loginPageUrl))
 }


### PR DESCRIPTION
Currently does not honour the `onStartSignUpGoTo` or `onSignUpGoTo` config params if they are set; it always goes to the login page.

`MailTokenBasedOperations.scala` will now redirect to whatever is specified in the config and if nothing set, will then redirect to login page.
