### PR TITLE
Change UserService trait to use the GenericProfile trait as the user type, instead of locking in the BasicProfile case class

### DIFF
--- a/module-code/app/securesocial/controllers/PasswordReset.scala
+++ b/module-code/app/securesocial/controllers/PasswordReset.scala
@@ -121,7 +121,7 @@ trait BasePasswordReset[U] extends MailTokenBasedOperations[U] {
                 case Some(profile) =>
                   val hashed = env.currentHasher.hash(p._1)
                   for (
-                    updated <- env.userService.save(profile.copy(passwordInfo = Some(hashed)), SaveMode.PasswordChange);
+                    updated <- env.userService.save(BasicProfile.from(profile).copy(passwordInfo = Some(hashed)), SaveMode.PasswordChange);
                     deleted <- env.userService.deleteToken(token)
                   ) yield {
                     env.mailer.sendPasswordChangedNotice(profile)

--- a/module-code/app/securesocial/controllers/ViewsPlugin.scala
+++ b/module-code/app/securesocial/controllers/ViewsPlugin.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
 import play.twirl.api.{ Html, Txt }
-import securesocial.core.{ BasicProfile, RuntimeEnvironment }
+import securesocial.core.{ GenericProfile, RuntimeEnvironment }
 
 /**
  * A trait that provides the pages for SecureSocial
@@ -88,7 +88,7 @@ trait MailTemplates {
    * @param request the current request
    * @return a tuple with the text and/or html body for the email
    */
-  def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getAlreadyRegisteredEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the welcome email sent when the user finished the sign up process
@@ -97,7 +97,7 @@ trait MailTemplates {
    * @param request the current request
    * @return a String with the text and/or html body for the email
    */
-  def getWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getWelcomeEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent when a user tries to reset the password but there is no account for
@@ -116,7 +116,7 @@ trait MailTemplates {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getSendPasswordResetEmail(user: GenericProfile, token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
 
   /**
    * Returns the email sent as a confirmation of a password change
@@ -125,7 +125,7 @@ trait MailTemplates {
    * @param request the current http request
    * @return a String with the text and/or html body for the email
    */
-  def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
+  def getPasswordChangedNoticeEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html])
 
 }
 
@@ -177,11 +177,11 @@ object MailTemplates {
       (None, Some(securesocial.views.html.mails.signUpEmail(token)))
     }
 
-    def getAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getAlreadyRegisteredEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.alreadyRegisteredEmail(user)))
     }
 
-    def getWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getWelcomeEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.welcomeEmail(user)))
     }
 
@@ -189,11 +189,11 @@ object MailTemplates {
       (None, Some(securesocial.views.html.mails.unknownEmailNotice()))
     }
 
-    def getSendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getSendPasswordResetEmail(user: GenericProfile, token: String)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.passwordResetEmail(user, token)))
     }
 
-    def getPasswordChangedNoticeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
+    def getPasswordChangedNoticeEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang): (Option[Txt], Option[Html]) = {
       (None, Some(securesocial.views.html.mails.passwordChangedNotice(user)))
     }
   }

--- a/module-code/app/securesocial/core/IdentityProvider.scala
+++ b/module-code/app/securesocial/core/IdentityProvider.scala
@@ -110,7 +110,7 @@ object AuthenticationResult {
    * Returned when the user was succesfully authenticated
    * @param profile the authenticated user profile
    */
-  case class Authenticated(profile: BasicProfile) extends AuthenticationResult
+  case class Authenticated(profile: GenericProfile) extends AuthenticationResult
 
   /**
    * Returned when the authentication process failed for some reason.

--- a/module-code/app/securesocial/core/UserProfile.scala
+++ b/module-code/app/securesocial/core/UserProfile.scala
@@ -55,6 +55,20 @@ case class BasicProfile(
   oAuth2Info: Option[OAuth2Info] = None,
   passwordInfo: Option[PasswordInfo] = None) extends GenericProfile
 
+object BasicProfile {
+  def from(p: GenericProfile) = BasicProfile(
+    providerId = p.providerId,
+    userId = p.userId,
+    firstName = p.firstName,
+    lastName = p.lastName,
+    fullName = p.fullName,
+    email = p.email,
+    avatarUrl = p.avatarUrl,
+    authMethod = p.authMethod,
+    oAuth1Info = p.oAuth1Info,
+    oAuth2Info = p.oAuth2Info,
+    passwordInfo = p.passwordInfo)
+}
 /**
  * The OAuth 1 details
  *

--- a/module-code/app/securesocial/core/java/BaseUserService.java
+++ b/module-code/app/securesocial/core/java/BaseUserService.java
@@ -21,7 +21,7 @@ import play.libs.Scala;
 import scala.*;
 import scala.Option;
 import scala.concurrent.Future;
-import securesocial.core.BasicProfile;
+import securesocial.core.GenericProfile;
 import securesocial.core.PasswordInfo;
 import securesocial.core.providers.MailToken;
 import securesocial.core.services.SaveMode;
@@ -45,10 +45,10 @@ public abstract class BaseUserService<U> implements UserService<U> {
      * @return an optional user
      */
     @Override
-    public Future<Option<BasicProfile>> find(String providerId, String userId) {
-        return doFind(providerId, userId).map(new F.Function<BasicProfile, Option<BasicProfile>>() {
+    public Future<Option<GenericProfile>> find(String providerId, String userId) {
+        return doFind(providerId, userId).map(new F.Function<GenericProfile, Option<GenericProfile>>() {
             @Override
-            public Option<BasicProfile> apply(BasicProfile user) throws Throwable {
+            public Option<GenericProfile> apply(GenericProfile user) throws Throwable {
                 return Scala.Option(user);
             }
         }).wrapped();
@@ -65,9 +65,9 @@ public abstract class BaseUserService<U> implements UserService<U> {
      * @return
      */
     @Override
-    public Future<Option<BasicProfile>> findByEmailAndProvider(String email, String providerId) {
-        return doFindByEmailAndProvider(email, providerId).map(new F.Function<BasicProfile, Option<BasicProfile>>() {
-            public Option<BasicProfile> apply(BasicProfile user) throws Throwable {
+    public Future<Option<GenericProfile>> findByEmailAndProvider(String email, String providerId) {
+        return doFindByEmailAndProvider(email, providerId).map(new F.Function<GenericProfile, Option<GenericProfile>>() {
+            public Option<GenericProfile> apply(GenericProfile user) throws Throwable {
                 return Scala.Option(user);
             }
         }).wrapped();
@@ -80,7 +80,7 @@ public abstract class BaseUserService<U> implements UserService<U> {
      * @param user
      */
     @Override
-    public Future<U> save(BasicProfile user, SaveMode mode) {
+    public Future<U> save(GenericProfile user, SaveMode mode) {
         return doSave(user, mode).wrapped();
     }
 
@@ -91,7 +91,7 @@ public abstract class BaseUserService<U> implements UserService<U> {
      * @param to The Identity that needs to be linked to the current user
      */
     @Override
-    public Future<U> link(U current, BasicProfile to) {
+    public Future<U> link(U current, GenericProfile to) {
         return doLink(current, to).wrapped();
     }
 
@@ -106,11 +106,11 @@ public abstract class BaseUserService<U> implements UserService<U> {
     }
 
     @Override
-    public Future<scala.Option<BasicProfile>> updatePasswordInfo(U user, PasswordInfo info) {
-        return doUpdatePasswordInfo(user, info).map(new F.Function<BasicProfile, Option<BasicProfile>>() {
+    public Future<scala.Option<GenericProfile>> updatePasswordInfo(U user, PasswordInfo info) {
+        return doUpdatePasswordInfo(user, info).map(new F.Function<GenericProfile, Option<GenericProfile>>() {
             @Override
-            public Option<BasicProfile> apply(BasicProfile basicProfile) throws Throwable {
-                return Scala.Option(basicProfile);
+            public Option<GenericProfile> apply(GenericProfile GenericProfile) throws Throwable {
+                return Scala.Option(GenericProfile);
             }
         }).wrapped();
     }
@@ -192,7 +192,7 @@ public abstract class BaseUserService<U> implements UserService<U> {
      *
      * @param user
      */
-    public abstract F.Promise<U> doSave(BasicProfile user, SaveMode mode);
+    public abstract F.Promise<U> doSave(GenericProfile user, SaveMode mode);
 
     /**
      * Saves a token
@@ -210,17 +210,17 @@ public abstract class BaseUserService<U> implements UserService<U> {
      * @param current The Identity of the current user
      * @param to The Identity that needs to be linked to the current user
      */
-    public abstract F.Promise<U> doLink(U current, BasicProfile to);
+    public abstract F.Promise<U> doLink(U current, GenericProfile to);
 
     /**
      * Finds the user in the backing store.
      * @return an Identity instance or null if no user matches the specified id
      */
-    public abstract F.Promise<BasicProfile> doFind(String providerId, String userId);
+    public abstract F.Promise<GenericProfile> doFind(String providerId, String userId);
 
     public abstract F.Promise<PasswordInfo>  doPasswordInfoFor(U user);
 
-    public abstract F.Promise<BasicProfile> doUpdatePasswordInfo(U user, PasswordInfo info);
+    public abstract F.Promise<GenericProfile> doUpdatePasswordInfo(U user, PasswordInfo info);
 
     /**
      * Finds a token
@@ -244,7 +244,7 @@ public abstract class BaseUserService<U> implements UserService<U> {
      * @param providerId - the provider id
      * @return an Identity instance or null if no user matches the specified id
      */
-    public abstract F.Promise<BasicProfile> doFindByEmailAndProvider(String email, String providerId);
+    public abstract F.Promise<GenericProfile> doFindByEmailAndProvider(String email, String providerId);
 
     /**
      * Deletes a token

--- a/module-code/app/securesocial/core/providers/UsernamePasswordProvider.scala
+++ b/module-code/app/securesocial/core/providers/UsernamePasswordProvider.scala
@@ -52,7 +52,7 @@ class UsernamePasswordProvider[U](userService: UserService[U],
     doAuthentication()
   }
 
-  private def profileForCredentials(userId: String, password: String): Future[Option[BasicProfile]] = {
+  private def profileForCredentials(userId: String, password: String): Future[Option[GenericProfile]] = {
     userService.find(id, userId).map { maybeUser =>
       for (
         user <- maybeUser;
@@ -71,10 +71,10 @@ class UsernamePasswordProvider[U](userService: UserService[U],
       NavigationFlow(badRequest(UsernamePasswordProvider.loginForm, Some(InvalidCredentials)))
   }
 
-  protected def withUpdatedAvatar(profile: BasicProfile): Future[BasicProfile] = {
+  protected def withUpdatedAvatar(profile: GenericProfile): Future[GenericProfile] = {
     (avatarService, profile.email) match {
       case (Some(service), Some(e)) => service.urlFor(e).map {
-        case url if url != profile.avatarUrl => profile.copy(avatarUrl = url)
+        case url if url != profile.avatarUrl => BasicProfile.from(profile).copy(avatarUrl = url)
         case _ => profile
       }
       case _ => Future.successful(profile)

--- a/module-code/app/securesocial/core/providers/utils/Mailer.scala
+++ b/module-code/app/securesocial/core/providers/utils/Mailer.scala
@@ -22,17 +22,17 @@ import play.api.libs.concurrent.Akka
 import play.api.mvc.RequestHeader
 import play.twirl.api.{ Txt, Html }
 import securesocial.controllers.MailTemplates
-import securesocial.core.BasicProfile
+import securesocial.core.GenericProfile
 /**
  * A helper trait to send email notifications
  */
 trait Mailer {
-  def sendAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang)
+  def sendAlreadyRegisteredEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang)
   def sendSignUpEmail(to: String, token: String)(implicit request: RequestHeader, lang: Lang)
-  def sendWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang)
-  def sendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang)
+  def sendWelcomeEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang)
+  def sendPasswordResetEmail(user: GenericProfile, token: String)(implicit request: RequestHeader, lang: Lang)
   def sendUnkownEmailNotice(email: String)(implicit request: RequestHeader, lang: Lang)
-  def sendPasswordChangedNotice(user: BasicProfile)(implicit request: RequestHeader, lang: Lang)
+  def sendPasswordChangedNotice(user: GenericProfile)(implicit request: RequestHeader, lang: Lang)
   def sendEmail(subject: String, recipient: String, body: (Option[Txt], Option[Html]))
 }
 
@@ -53,7 +53,7 @@ object Mailer {
     val UnknownEmailNoticeSubject = "mails.unknownEmail.subject"
     val PasswordResetOkSubject = "mails.passwordResetOk.subject"
 
-    override def sendAlreadyRegisteredEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang) {
+    override def sendAlreadyRegisteredEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang) {
       val txtAndHtml = mailTemplates.getAlreadyRegisteredEmail(user)
       sendEmail(Messages(AlreadyRegisteredSubject), user.email.get, txtAndHtml)
 
@@ -64,13 +64,13 @@ object Mailer {
       sendEmail(Messages(SignUpEmailSubject), to, txtAndHtml)
     }
 
-    override def sendWelcomeEmail(user: BasicProfile)(implicit request: RequestHeader, lang: Lang) {
+    override def sendWelcomeEmail(user: GenericProfile)(implicit request: RequestHeader, lang: Lang) {
       val txtAndHtml = mailTemplates.getWelcomeEmail(user)
       sendEmail(Messages(WelcomeEmailSubject), user.email.get, txtAndHtml)
 
     }
 
-    override def sendPasswordResetEmail(user: BasicProfile, token: String)(implicit request: RequestHeader, lang: Lang) {
+    override def sendPasswordResetEmail(user: GenericProfile, token: String)(implicit request: RequestHeader, lang: Lang) {
       val txtAndHtml = mailTemplates.getSendPasswordResetEmail(user, token)
       sendEmail(Messages(PasswordResetSubject), user.email.get, txtAndHtml)
     }
@@ -80,7 +80,7 @@ object Mailer {
       sendEmail(Messages(UnknownEmailNoticeSubject), email, txtAndHtml)
     }
 
-    override def sendPasswordChangedNotice(user: BasicProfile)(implicit request: RequestHeader, lang: Lang) {
+    override def sendPasswordChangedNotice(user: GenericProfile)(implicit request: RequestHeader, lang: Lang) {
       val txtAndHtml = mailTemplates.getPasswordChangedNoticeEmail(user)
       sendEmail(Messages(PasswordResetOkSubject), user.email.get, txtAndHtml)
     }

--- a/module-code/app/securesocial/core/services/UserService.scala
+++ b/module-code/app/securesocial/core/services/UserService.scala
@@ -17,7 +17,7 @@
 package securesocial.core.services
 
 import scala.concurrent.Future
-import securesocial.core.{ PasswordInfo, BasicProfile }
+import securesocial.core.{ PasswordInfo, GenericProfile }
 import securesocial.core.providers.MailToken
 
 trait UserService[U] {
@@ -29,7 +29,7 @@ trait UserService[U] {
    * @param userId the user id
    * @return an optional profile
    */
-  def find(providerId: String, userId: String): Future[Option[BasicProfile]]
+  def find(providerId: String, userId: String): Future[Option[GenericProfile]]
 
   /**
    * Finds a profile by email and provider
@@ -38,7 +38,7 @@ trait UserService[U] {
    * @param providerId - the provider id
    * @return an optional profile
    */
-  def findByEmailAndProvider(email: String, providerId: String): Future[Option[BasicProfile]]
+  def findByEmailAndProvider(email: String, providerId: String): Future[Option[GenericProfile]]
 
   /**
    * Saves a profile.  This method gets called when a user logs in, registers or changes his password.
@@ -47,7 +47,7 @@ trait UserService[U] {
    * @param profile the user profile
    * @param mode a mode that tells you why the save method was called
    */
-  def save(profile: BasicProfile, mode: SaveMode): Future[U]
+  def save(profile: GenericProfile, mode: SaveMode): Future[U]
 
   /**
    * Links the current user to another profile
@@ -55,7 +55,7 @@ trait UserService[U] {
    * @param current The current user instance
    * @param to the profile that needs to be linked to
    */
-  def link(current: U, to: BasicProfile): Future[U]
+  def link(current: U, to: GenericProfile): Future[U]
 
   /**
    * Returns an optional PasswordInfo instance for a given user
@@ -72,7 +72,7 @@ trait UserService[U] {
    * @param info the password info
    * @return
    */
-  def updatePasswordInfo(user: U, info: PasswordInfo): Future[Option[BasicProfile]]
+  def updatePasswordInfo(user: U, info: PasswordInfo): Future[Option[GenericProfile]]
 
   /**
    * Saves a mail token.  This is needed for users that

--- a/module-code/app/securesocial/views/mails/alreadyRegisteredEmail.scala.html
+++ b/module-code/app/securesocial/views/mails/alreadyRegisteredEmail.scala.html
@@ -1,4 +1,4 @@
-@(user: securesocial.core.BasicProfile)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
+@(user: securesocial.core.GenericProfile)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
 
 <html>
     <body>

--- a/module-code/app/securesocial/views/mails/passwordChangedNotice.scala.html
+++ b/module-code/app/securesocial/views/mails/passwordChangedNotice.scala.html
@@ -1,4 +1,4 @@
-@(user: securesocial.core.BasicProfile)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
+@(user: securesocial.core.GenericProfile)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
 
 <html>
 <body>

--- a/module-code/app/securesocial/views/mails/passwordResetEmail.scala.html
+++ b/module-code/app/securesocial/views/mails/passwordResetEmail.scala.html
@@ -1,4 +1,4 @@
-@(user: securesocial.core.BasicProfile, mailToken: String)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
+@(user: securesocial.core.GenericProfile, mailToken: String)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
 @import securesocial.core.IdentityProvider
 <html>
 <body>

--- a/module-code/app/securesocial/views/mails/welcomeEmail.scala.html
+++ b/module-code/app/securesocial/views/mails/welcomeEmail.scala.html
@@ -1,4 +1,4 @@
-@(user: securesocial.core.BasicProfile)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
+@(user: securesocial.core.GenericProfile)(implicit request: RequestHeader, lang: Lang, env: securesocial.core.RuntimeEnvironment[_])
 <html>
 <body>
 <p>Welcome @user.firstName,</p>

--- a/samples/java/demo/app/service/InMemoryUserService.java
+++ b/samples/java/demo/app/service/InMemoryUserService.java
@@ -19,6 +19,7 @@ package service;
 import play.Logger;
 import play.libs.F;
 import securesocial.core.BasicProfile;
+import securesocial.core.GenericProfile;
 import securesocial.core.PasswordInfo;
 import securesocial.core.services.SaveMode;
 import securesocial.core.java.BaseUserService;
@@ -42,8 +43,9 @@ public class InMemoryUserService extends BaseUserService<DemoUser> {
     private HashMap<String, Token> tokens = new HashMap<String, Token>();
 
     @Override
-    public F.Promise<DemoUser> doSave(BasicProfile profile, SaveMode mode) {
+    public F.Promise<DemoUser> doSave(GenericProfile gp, SaveMode mode) {
         DemoUser result = null;
+        BasicProfile profile = BasicProfile.from(gp);
         if (mode == SaveMode.SignUp()) {
             result = new DemoUser(profile);
             users.put(profile.providerId() + profile.userId(), result);
@@ -78,7 +80,8 @@ public class InMemoryUserService extends BaseUserService<DemoUser> {
     }
 
     @Override
-    public F.Promise<DemoUser> doLink(DemoUser current, BasicProfile to) {
+    public F.Promise<DemoUser> doLink(DemoUser current, GenericProfile gto) {
+        BasicProfile to = BasicProfile.from(gto);
         DemoUser target = null;
 
         for ( DemoUser u: users.values() ) {
@@ -111,11 +114,11 @@ public class InMemoryUserService extends BaseUserService<DemoUser> {
     }
 
     @Override
-    public F.Promise<BasicProfile> doFind(String providerId, String userId) {
+    public F.Promise<GenericProfile> doFind(String providerId, String userId) {
         if(logger.isDebugEnabled()){
             logger.debug("Finding user " + userId);
         }
-        BasicProfile found = null;
+        GenericProfile found = null;
 
         for ( DemoUser u: users.values() ) {
             for ( BasicProfile i : u.identities ) {
@@ -135,7 +138,7 @@ public class InMemoryUserService extends BaseUserService<DemoUser> {
     }
 
     @Override
-    public F.Promise<BasicProfile> doUpdatePasswordInfo(DemoUser user, PasswordInfo info) {
+    public F.Promise<GenericProfile> doUpdatePasswordInfo(DemoUser user, PasswordInfo info) {
         throw new RuntimeException("doUpdatePasswordInfo is not implemented yet in sample app");
     }
 
@@ -146,8 +149,8 @@ public class InMemoryUserService extends BaseUserService<DemoUser> {
 
 
     @Override
-    public F.Promise<BasicProfile> doFindByEmailAndProvider(String email, String providerId) {
-        BasicProfile found = null;
+    public F.Promise<GenericProfile> doFindByEmailAndProvider(String email, String providerId) {
+        GenericProfile found = null;
 
         for ( DemoUser u: users.values() ) {
             for ( BasicProfile i : u.identities ) {

--- a/samples/scala/demo/app/service/InMemoryUserService.scala
+++ b/samples/scala/demo/app/service/InMemoryUserService.scala
@@ -78,7 +78,8 @@ class InMemoryUserService extends UserService[DemoUser] {
     Future.successful(updatedUser)
   }
 
-  def save(user: BasicProfile, mode: SaveMode): Future[DemoUser] = {
+  def save(guser: GenericProfile, mode: SaveMode): Future[DemoUser] = {
+    val user = BasicProfile.from(guser)
     mode match {
       case SaveMode.SignUp =>
         val newUser = DemoUser(user, List(user))
@@ -104,7 +105,8 @@ class InMemoryUserService extends UserService[DemoUser] {
     }
   }
 
-  def link(current: DemoUser, to: BasicProfile): Future[DemoUser] = {
+  def link(current: DemoUser, gto: GenericProfile): Future[DemoUser] = {
+    val to = BasicProfile.from(gto)
     if (current.identities.exists(i => i.providerId == to.providerId && i.userId == to.userId)) {
       Future.successful(current)
     } else {


### PR DESCRIPTION
Since it isn't possible to subclass a case class, and implementors may have a different structure for users than the `BasicProfile`, and in general, it is best to stick to the [Robustness Principle](http://en.wikipedia.org/wiki/Robustness_principle) (and I'm guessing this is why the `GenericProfile` trait exists in the first place?)

In my case, I needed this because I am migrating from an old version of SecureSocial, where the `IdentityId` was a thing.  I didn't want to migrate all of my user records in mongo, or tack on a transformation step in my DB layer.  I imagine others may have other reasons for wanting to have the freedom to implement `GenericProfile` differently.

Of course, implementors are still free to just use `BasicProfile`.