### PR TITLE
Add extraInfo to BasicProfile

### DIFF
--- a/module-code/app/securesocial/core/UserProfile.scala
+++ b/module-code/app/securesocial/core/UserProfile.scala
@@ -53,7 +53,8 @@ case class BasicProfile(
   authMethod: AuthenticationMethod,
   oAuth1Info: Option[OAuth1Info] = None,
   oAuth2Info: Option[OAuth2Info] = None,
-  passwordInfo: Option[PasswordInfo] = None) extends GenericProfile
+  passwordInfo: Option[PasswordInfo] = None,
+  extraInfo: Option[Map[String, String]] = None) extends GenericProfile
 
 /**
  * The OAuth 1 details


### PR DESCRIPTION
Some providers provide extra information not contained in `BasicProfile`, and we sometimes want to use that. This PR adds an `extraInfo` field to `BasicProfile`.

An example of usage of this change is here:
https://github.com/k4200/securesocial/commit/26fb682d65fee82de100ec47490b3911f3e6ddf7

Thanks.
