### PR TITLE
added missing @inject annotation for UserAware

### DIFF
--- a/module-code/app/securesocial/core/java/UserAware.java
+++ b/module-code/app/securesocial/core/java/UserAware.java
@@ -25,6 +25,7 @@ import securesocial.core.RuntimeEnvironment;
 import securesocial.core.authenticator.Authenticator;
 
 import static play.libs.F.Promise;
+import javax.inject.Inject;
 
 /**
  * An action that puts the current user in the context if there's one available. This is useful in
@@ -43,6 +44,7 @@ import static play.libs.F.Promise;
 public class UserAware extends Action<UserAwareAction> {
     RuntimeEnvironment env;
 
+    @Inject
     public UserAware(RuntimeEnvironment env) throws Throwable {
         this.env = env;
     }


### PR DESCRIPTION
Should solve the below error for users.

1) Could not find a suitable constructor in securesocial.core.java.UserAware. Classes must have either one (and only one) constructor annotated with @Inject or a zero-argument constructor that is not private.
  at securesocial.core.java.UserAware.class(UserAware.java:46)
  while locating securesocial.core.java.UserAware