### PR TITLE
Store scope in OAuth2Info

### DIFF
--- a/module-code/app/securesocial/core/OAuth2Provider.scala
+++ b/module-code/app/securesocial/core/OAuth2Provider.scala
@@ -93,7 +93,8 @@ abstract class OAuth2Provider(
       (json \ OAuth2Constants.AccessToken).as[String],
       (json \ OAuth2Constants.TokenType).asOpt[String],
       (json \ OAuth2Constants.ExpiresIn).asOpt[Int],
-      (json \ OAuth2Constants.RefreshToken).asOpt[String]
+      (json \ OAuth2Constants.RefreshToken).asOpt[String],
+      (json \ OAuth2Constants.Scope).asOpt[String]
     )
   }
 
@@ -107,8 +108,8 @@ abstract class OAuth2Provider(
   private[this] def authenticateCallback(request: Request[AnyContent], code: String): Future[AuthenticationResult] = {
     validateOauthState(request).flatMap(stateOk => if (stateOk) {
       for {
-        accessToken <- getAccessToken(code)(request) if stateOk;
-        user <- fillProfile(OAuth2Info(accessToken.accessToken, accessToken.tokenType, accessToken.expiresIn, accessToken.refreshToken))
+        oAuth2Info <- getAccessToken(code)(request) if stateOk;
+        user <- fillProfile(oAuth2Info)
       } yield {
         logger.debug(s"[securesocial] user loggedin using provider $id = $user")
         AuthenticationResult.Authenticated(user)

--- a/module-code/app/securesocial/core/UserProfile.scala
+++ b/module-code/app/securesocial/core/UserProfile.scala
@@ -70,9 +70,10 @@ case class OAuth1Info(token: String, secret: String)
  * @param tokenType the token type
  * @param expiresIn the number of seconds before the token expires
  * @param refreshToken the refresh token
+ * @param scope the scope
  */
 case class OAuth2Info(accessToken: String, tokenType: Option[String] = None,
-  expiresIn: Option[Int] = None, refreshToken: Option[String] = None)
+  expiresIn: Option[Int] = None, refreshToken: Option[String] = None, scope: Option[String] = None)
 
 /**
  * The password details

--- a/module-code/app/securesocial/core/providers/GitHubProvider.scala
+++ b/module-code/app/securesocial/core/providers/GitHubProvider.scala
@@ -53,7 +53,8 @@ class GitHubProvider(routesService: RoutesService,
       accessToken.get,
       values.get(OAuth2Constants.TokenType),
       values.get(OAuth2Constants.ExpiresIn).map(_.toInt),
-      values.get(OAuth2Constants.RefreshToken)
+      values.get(OAuth2Constants.RefreshToken),
+      values.get(OAuth2Constants.Scope)
     )
   }
 


### PR DESCRIPTION
Some OAuth2 providers return "scope" along with the access token, which is part of the OAuth2 spec. This PR enables to store it in `OAuth2Info` so that the user application can utilize it. 

This is useful especially for GitHub since it allows the user to obtain multiple access tokens, and some user applications should be interested in the scope of the access token that they get from the API.
https://developer.github.com/v3/oauth/#multiple-tokens
