### PR TITLE
Fix missing binding in scala demo

### DIFF
--- a/samples/scala/demo/app/service/MyEnvironment.scala
+++ b/samples/scala/demo/app/service/MyEnvironment.scala
@@ -52,4 +52,6 @@ class MyEnvironment @Inject() (
     ListMap(customProviders.list.map(include): _*) ++ builtInProviders
 }
 
-case class CustomProviders(list: Seq[IdentityProvider])
+case class CustomProviders(list: Seq[IdentityProvider]) {
+  @Inject def this() = this(Seq.empty)
+}


### PR DESCRIPTION
I noticed the scala demo doesn't start in dev mode anymore because of a missing binding. I just changed the `CustomProviders` class to have a default constructor with `@Inject`. That class is just used to inject extra providers in the test.