### PR TITLE
Remove Controller trait from EventListener

### DIFF
--- a/module-code/app/securesocial/core/Events.scala
+++ b/module-code/app/securesocial/core/Events.scala
@@ -60,7 +60,7 @@ case class PasswordResetEvent[U](override val user: U) extends Event(user)
 /**
  * The event listener interface
  */
-abstract class EventListener extends Controller {
+abstract class EventListener {
 
   /**
    * The method that gets called when an event occurs.

--- a/samples/scala/demo/app/service/MyEnvironment.scala
+++ b/samples/scala/demo/app/service/MyEnvironment.scala
@@ -35,7 +35,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class MyEnvironment @Inject() (
   override val configuration: Configuration,
-  override val messagesApi: MessagesApi,
+  override implicit val messagesApi: MessagesApi,
   override val environment: Environment,
   override val wsClient: WSClient,
   override val cacheApi: AsyncCacheApi,
@@ -47,7 +47,7 @@ class MyEnvironment @Inject() (
   override type U = DemoUser
   override lazy val routes = new CustomRoutesService(environment, configuration)
   override lazy val userService: InMemoryUserService = new InMemoryUserService()
-  override lazy val eventListeners = List(new MyEventListener())
+  override lazy val eventListeners = List(new MyEventListener)
   override lazy val providers: ListMap[String, IdentityProvider] =
     ListMap(customProviders.list.map(include): _*) ++ builtInProviders
 }

--- a/samples/scala/demo/app/service/MyEventListener.scala
+++ b/samples/scala/demo/app/service/MyEventListener.scala
@@ -17,13 +17,14 @@
 package service
 
 import securesocial.core._
-import play.api.mvc.{ Session, RequestHeader }
+import play.api.mvc.{ RequestHeader, Session }
 import play.api.Logger
+import play.api.i18n.{ I18nSupport, MessagesApi }
 
 /**
  * A sample event listener
  */
-class MyEventListener extends EventListener {
+class MyEventListener()(implicit val messagesApi: MessagesApi) extends EventListener with I18nSupport {
 
   def onEvent[U](event: Event[U], request: RequestHeader, session: Session): Option[Session] = {
     val eventName = event match {
@@ -40,7 +41,7 @@ class MyEventListener extends EventListener {
     }
 
     // retrieving the current language
-    Logger.info("current language is %s".format(request2lang(request)))
+    Logger.info("current language is %s".format(request.lang))
 
     // Not changing the session so just return None
     // if you wanted to change the session then you'd do something like


### PR DESCRIPTION
`Controller` now is deprecated in favor of `BaseController` and other traits that have injected dependencies. It seems strange for the `EventListener` interface extend `Controller` so I just removed the trait. The example was also using `request2lang` which would break if global state were disabled.