### PR TITLE
play 2.7.0-M2

### DIFF
--- a/module-code/app/securesocial/core/java/InvokeDelegate.java
+++ b/module-code/app/securesocial/core/java/InvokeDelegate.java
@@ -16,14 +16,13 @@
  */
 package securesocial.core.java;
 
-import play.libs.concurrent.HttpExecution;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
-import scala.concurrent.ExecutionContextExecutor;
 import securesocial.core.authenticator.Authenticator;
 
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import static scala.compat.java8.FutureConverters.toJava;
@@ -31,16 +30,18 @@ import static scala.compat.java8.FutureConverters.toJava;
 class InvokeDelegate implements Function<Authenticator<Object>, CompletionStage<Result>> {
     private final Http.Context ctx;
     private final Action<?> delegate;
+    private Executor executor;
 
-    InvokeDelegate(Http.Context ctx, Action<?> delegate) {
+    InvokeDelegate(Http.Context ctx, Action<?> delegate, Executor executor) {
         this.ctx = ctx;
         this.delegate = delegate;
+        this.executor = executor;
     }
 
     @Override
     public CompletionStage<Result> apply(Authenticator<Object> authenticator) {
         ctx.args.put(SecureSocial.USER_KEY, authenticator.user());
         return toJava(authenticator.touching(ctx))
-                .thenComposeAsync(boxedUnit -> delegate.call(ctx), HttpExecution.defaultContext());
+                .thenComposeAsync(boxedUnit -> delegate.call(ctx), executor);
     }
 }

--- a/module-code/app/securesocial/core/java/SecureSocial.java
+++ b/module-code/app/securesocial/core/java/SecureSocial.java
@@ -17,7 +17,6 @@
 package securesocial.core.java;
 
 import play.api.mvc.RequestHeader;
-import play.libs.concurrent.HttpExecution;
 import play.mvc.Http;
 import scala.Option;
 import scala.concurrent.ExecutionContext;
@@ -57,7 +56,7 @@ public class SecureSocial {
      * @return the current user object or null if there isn't one available
      */
     public static CompletionStage<Object> currentUser(RuntimeEnvironment env) {
-        return currentUser(env, HttpExecution.defaultContext());
+        return currentUser(env, env.executionContext());
     }
 
     /**

--- a/module-code/app/securesocial/core/java/UserAware.java
+++ b/module-code/app/securesocial/core/java/UserAware.java
@@ -57,13 +57,13 @@ public class UserAware extends Action<UserAwareAction> {
     public CompletionStage<Result> call(final Http.Context ctx)  {
         try {
             Secured.initEnv(env);
-            ExecutionContextExecutor executor = HttpExecution.defaultContext();
+            ExecutionContextExecutor executor = HttpExecution.fromThread(env.executionContext());
             return toJava(env.authenticatorService().fromRequest(ctx._requestHeader()))
                     .thenComposeAsync(authenticatorOption -> {
                         if (authenticatorOption.isDefined() && authenticatorOption.get().isValid()) {
                             Authenticator<Object> authenticator = authenticatorOption.get();
                             return toJava(authenticator.touch())
-                                    .thenComposeAsync(new InvokeDelegate(ctx, delegate), executor);
+                                    .thenComposeAsync(new InvokeDelegate(ctx, delegate, executor), executor);
                         } else {
                             return delegate.call(ctx);
                         }

--- a/module-code/app/securesocial/core/services/AuthenticatorService.scala
+++ b/module-code/app/securesocial/core/services/AuthenticatorService.scala
@@ -20,7 +20,6 @@ import play.api.mvc.RequestHeader
 import scala.concurrent.{ ExecutionContext, Future }
 import securesocial.core.authenticator.{ Authenticator, AuthenticatorBuilder }
 import scala.reflect.ClassTag
-import org.apache.commons.lang3.reflect.TypeUtils
 
 class AuthenticatorService[U](builders: AuthenticatorBuilder[U]*)(implicit val executionContext: ExecutionContext) {
   private val logger = play.api.Logger(getClass.getName)
@@ -32,7 +31,7 @@ class AuthenticatorService[U](builders: AuthenticatorBuilder[U]*)(implicit val e
 
   def findAs[T <: AuthenticatorBuilder[U]](id: String)(implicit ct: ClassTag[T]): Option[T] = {
     find(id) map {
-      case builder if TypeUtils.isInstance(builder, ct.runtimeClass) => builder.asInstanceOf[T]
+      case builder if builder.isInstanceOf[T] => builder.asInstanceOf[T]
     }
   }
 

--- a/module-code/test/securesocial/core/OAuth2ClientSpec.scala
+++ b/module-code/test/securesocial/core/OAuth2ClientSpec.scala
@@ -8,39 +8,36 @@ import play.api.libs.json.{ JsObject, Json }
 import play.api.libs.ws.WSResponse
 import securesocial.core.services.HttpService
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class OAuth2ClientSpec extends Specification with Mockito {
+class OAuth2ClientSpec(implicit ee: ExecutionEnv) extends Specification with Mockito {
   "The default OAuth2Client" should {
     import MockHttpService._
     "exchange a signin code for a token" in {
-      implicit ee: ExecutionEnv =>
-        val httpService: MockHttpService = new MockHttpService()
-        val client = aDefaultClient(httpService)
-        val (code, callbackUrl) = ("code", "callbackUrl")
-        val expectedJson: JsObject = Json.obj("expected" -> "object")
-        val expectedToken = OAuth2Info("accessToken")
+      val httpService: MockHttpService = new MockHttpService()
+      val client = aDefaultClient(httpService)
+      val (code, callbackUrl) = ("code", "callbackUrl")
+      val expectedJson: JsObject = Json.obj("expected" -> "object")
+      val expectedToken = OAuth2Info("accessToken")
 
-        httpService.request.post(any[Params])(any[ParamsWriter]) returns Future.successful(httpService.response)
-        httpService.response.json returns expectedJson
+      httpService.request.post(any[Params])(any[ParamsWriter]) returns Future.successful(httpService.response)
+      httpService.response.json returns expectedJson
 
-        val builder: WSResponse => OAuth2Info = (response: WSResponse) => if (response.json == expectedJson) expectedToken else throw new RuntimeException(s"Expected ${response.json} to be $expectedJson")
-        val token: Future[OAuth2Info] = client.exchangeCodeForToken(code, callbackUrl, builder)
+      val builder: WSResponse => OAuth2Info = (response: WSResponse) => if (response.json == expectedJson) expectedToken else throw new RuntimeException(s"Expected ${response.json} to be $expectedJson")
+      val token: Future[OAuth2Info] = client.exchangeCodeForToken(code, callbackUrl, builder)
 
-        token must beEqualTo(expectedToken).await
+      token must beEqualTo(expectedToken).await
     }
     "retrieve the profile given an access token" in {
-      implicit ee: ExecutionEnv =>
-        val httpService: MockHttpService = new MockHttpService()
-        val client = aDefaultClient(httpService)
-        val profileUrl = "profileUrl"
-        val expectedJson: JsObject = Json.obj("expected" -> "object")
-        httpService.response.json returns expectedJson
+      val httpService: MockHttpService = new MockHttpService()
+      val client = aDefaultClient(httpService)
+      val profileUrl = "profileUrl"
+      val expectedJson: JsObject = Json.obj("expected" -> "object")
+      httpService.response.json returns expectedJson
 
-        val actualProfile = client.retrieveProfile(profileUrl)
+      val actualProfile = client.retrieveProfile(profileUrl)
 
-        actualProfile must beEqualTo(expectedJson).await
+      actualProfile must beEqualTo(expectedJson).await
     }
 
   }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -2,7 +2,7 @@
 
 object Common {
   def version = "master-SNAPSHOT"  
-  def playVersion = System.getProperty("play.version", "2.6.12")
+  def playVersion = System.getProperty("play.version", "2.7.0-M2")
   def scalaVersion = System.getProperty("scala.version", "2.12.6")
   def crossScalaVersions = Seq(scalaVersion, "2.11.12")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += Resolver.typesafeRepo("releases")
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.6.11"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.7.0-M2"))
 
 // Add Scalariform
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")


### PR DESCRIPTION
* `org.apache.commons.lang3.reflect.TypeUtils` is no longer a dependency
* most changes related to `play.libs.concurrent.HttpExecution.defaultContext` no longer available 

lets keep this PR open while 2.7 is not released